### PR TITLE
Add ability to verify and restore metadata

### DIFF
--- a/pkg/cmd/dockerregistry/listfs.go
+++ b/pkg/cmd/dockerregistry/listfs.go
@@ -1,0 +1,106 @@
+package dockerregistry
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/registry/storage"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+
+	registryconfig "github.com/openshift/image-registry/pkg/dockerregistry/server/configuration"
+	regstorage "github.com/openshift/image-registry/pkg/dockerregistry/server/storage"
+)
+
+type ListOptions struct {
+	Repositories      bool
+	Blobs             bool
+	Manifests         bool
+	ManifestsFromRepo string
+}
+
+func ExecuteListFS(configFile io.Reader, opts *ListOptions) {
+	config, _, err := registryconfig.Parse(configFile)
+	if err != nil {
+		log.Fatalf("error parsing configuration file: %s", err)
+	}
+
+	// A lot of installations have the 'debug' log level in their config files,
+	// but it's too verbose for pruning. Therefore we ignore it, but we still
+	// respect overrides using environment variables.
+	config.Loglevel = ""
+	config.Log.Level = configuration.Loglevel(os.Getenv("REGISTRY_LOG_LEVEL"))
+	if len(config.Log.Level) == 0 {
+		config.Log.Level = "warning"
+	}
+
+	ctx := context.Background()
+	ctx, err = configureLogging(ctx, config)
+	if err != nil {
+		log.Fatalf("error configuring logging: %s", err)
+	}
+
+	storageDriver, err := factory.Create(config.Storage.Type(), config.Storage.Parameters())
+	if err != nil {
+		log.Fatalf("error creating storage driver: %s", err)
+	}
+
+	registry, err := storage.NewRegistry(ctx, storageDriver)
+	if err != nil {
+		log.Fatalf("error creating registry: %s", err)
+	}
+
+	enumStorage := regstorage.Enumerator{Registry: registry}
+
+	var repoList []string
+
+	if opts.Repositories {
+		err := enumStorage.Repositories(ctx, func(repoName string) error {
+			fmt.Printf("repository\t%s\n", repoName)
+			repoList = append(repoList, repoName)
+			return nil
+		})
+		if err != nil {
+			log.Fatalf("unable to list repositories: %s", err)
+		}
+	}
+
+	if opts.Blobs {
+		err := enumStorage.Blobs(ctx, func(dgst digest.Digest) error {
+			fmt.Printf("blob\t%s\n", dgst)
+			return nil
+		})
+		if err != nil {
+			log.Fatalf("unable to list repositories: %s", err)
+		}
+	}
+
+	if opts.Manifests {
+		if len(opts.ManifestsFromRepo) > 0 {
+			repoList = []string{opts.ManifestsFromRepo}
+		} else if !opts.Repositories {
+			err := enumStorage.Repositories(ctx, func(repoName string) error {
+				repoList = append(repoList, repoName)
+				return nil
+			})
+			if err != nil {
+				log.Fatalf("unable to list repositories: %s", err)
+			}
+		}
+
+		for _, repoName := range repoList {
+			err := enumStorage.Manifests(ctx, repoName, func(dgst digest.Digest) error {
+				fmt.Printf("manifest\t%s\t%s\n", repoName, dgst)
+				return nil
+			})
+			if err != nil {
+				log.Fatalf("unable to list manifests in the %q repository: %s", repoName, err)
+			}
+		}
+	}
+}

--- a/pkg/cmd/dockerregistry/prune.go
+++ b/pkg/cmd/dockerregistry/prune.go
@@ -1,0 +1,88 @@
+package dockerregistry
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/go-units"
+
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/storage"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+	registryconfig "github.com/openshift/image-registry/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/prune"
+	"github.com/openshift/image-registry/pkg/origin-common/clientcmd"
+)
+
+// ExecutePruner runs the pruner.
+func ExecutePruner(configFile io.Reader, dryRun bool) {
+	config, extraConfig, err := registryconfig.Parse(configFile)
+	if err != nil {
+		log.Fatalf("error parsing configuration file: %s", err)
+	}
+
+	// A lot of installations have the 'debug' log level in their config files,
+	// but it's too verbose for pruning. Therefore we ignore it, but we still
+	// respect overrides using environment variables.
+	config.Loglevel = ""
+	config.Log.Level = configuration.Loglevel(os.Getenv("REGISTRY_LOG_LEVEL"))
+	if len(config.Log.Level) == 0 {
+		config.Log.Level = "warning"
+	}
+
+	ctx := context.Background()
+	ctx, err = configureLogging(ctx, config)
+	if err != nil {
+		log.Fatalf("error configuring logging: %s", err)
+	}
+
+	startPrune := "start prune"
+	var registryOptions []storage.RegistryOption
+	if dryRun {
+		startPrune += " (dry-run mode)"
+	} else {
+		registryOptions = append(registryOptions, storage.EnableDelete)
+	}
+	context.GetLoggerWithFields(ctx, versionFields()).Info(startPrune)
+
+	registryClient := client.NewRegistryClient(clientcmd.NewConfig().BindToFile(extraConfig.KubeConfig))
+
+	storageDriver, err := factory.Create(config.Storage.Type(), config.Storage.Parameters())
+	if err != nil {
+		log.Fatalf("error creating storage driver: %s", err)
+	}
+
+	registry, err := storage.NewRegistry(ctx, storageDriver, registryOptions...)
+	if err != nil {
+		log.Fatalf("error creating registry: %s", err)
+	}
+
+	var pruner prune.Pruner
+
+	if dryRun {
+		pruner = &prune.DryRunPruner{}
+	} else {
+		pruner = &prune.RegistryPruner{StorageDriver: storageDriver}
+	}
+
+	stats, err := prune.Prune(ctx, registry, registryClient, pruner)
+	if err != nil {
+		log.Error(err)
+	}
+	if dryRun {
+		fmt.Printf("Would delete %d blobs\n", stats.Blobs)
+		fmt.Printf("Would free up %s of disk space\n", units.BytesSize(float64(stats.DiskSpace)))
+		fmt.Println("Use -prune=delete to actually delete the data")
+	} else {
+		fmt.Printf("Deleted %d blobs\n", stats.Blobs)
+		fmt.Printf("Freed up %s of disk space\n", units.BytesSize(float64(stats.DiskSpace)))
+	}
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/dockerregistry/restore.go
+++ b/pkg/cmd/dockerregistry/restore.go
@@ -1,0 +1,98 @@
+package dockerregistry
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/distribution/configuration"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/storage"
+	"github.com/docker/distribution/registry/storage/driver/factory"
+
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+	registryconfig "github.com/openshift/image-registry/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/prune"
+	"github.com/openshift/image-registry/pkg/origin-common/clientcmd"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ExecuteRestore(configFile io.Reader, mode, namespace string) {
+	if len(namespace) == 0 {
+		namespace = metav1.NamespaceAll
+	}
+
+	dockerConfig, config, err := registryconfig.Parse(configFile)
+	if err != nil {
+		log.Fatalf("error parsing configuration file: %s", err)
+	}
+
+	registryClient := client.NewRegistryClient(clientcmd.NewConfig().BindToFile(config.KubeConfig))
+
+	// A lot of installations have the 'debug' log level in their config files,
+	// but it's too verbose for pruning. Therefore we ignore it, but we still
+	// respect overrides using environment variables.
+	dockerConfig.Loglevel = ""
+	dockerConfig.Log.Level = configuration.Loglevel(os.Getenv("REGISTRY_LOG_LEVEL"))
+	if len(dockerConfig.Log.Level) == 0 {
+		dockerConfig.Log.Level = "fatal"
+	}
+
+	ctx := context.Background()
+
+	ctx, err = configureLogging(ctx, dockerConfig)
+	if err != nil {
+		log.Fatalf("error configuring logging: %s", err)
+	}
+
+	storageDriver, err := factory.Create(dockerConfig.Storage.Type(), dockerConfig.Storage.Parameters())
+	if err != nil {
+		log.Fatalf("error creating storage driver: %s", err)
+	}
+
+	client, err := registryClient.Client()
+	if err != nil {
+		log.Fatalf("error getting clients: %v", err)
+	}
+
+	registry, err := storage.NewRegistry(ctx, storageDriver)
+	if err != nil {
+		log.Fatalf("error creating registry: %s", err)
+	}
+
+	var restore prune.Restore
+
+	if strings.HasPrefix(mode, "check") {
+		restore = &prune.DryRunRestore{}
+	} else {
+		restore = &prune.StorageRestore{
+			Ctx:    ctx,
+			Client: client,
+		}
+	}
+
+	fsck := &prune.Fsck{
+		Ctx:        ctx,
+		Client:     client,
+		Registry:   registry,
+		ServerAddr: config.Server.Addr,
+		Restore:    restore,
+	}
+
+	switch mode {
+	case "check", "check-storage", "recover":
+		if err := fsck.Storage(namespace); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	switch mode {
+	case "check", "check-database", "recover":
+		if err := fsck.Database(namespace); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -90,6 +90,7 @@ var _ ImageStreamInterface = imageclientv1.ImageStreamInterface(nil)
 type ImageStreamInterface interface {
 	Get(name string, options metav1.GetOptions) (*imageapiv1.ImageStream, error)
 	Create(stream *imageapiv1.ImageStream) (*imageapiv1.ImageStream, error)
+	List(opts metav1.ListOptions) (*imageapiv1.ImageStreamList, error)
 }
 
 var _ ImageStreamMappingInterface = imageclientv1.ImageStreamMappingInterface(nil)

--- a/pkg/dockerregistry/server/manifesthandler/doc.go
+++ b/pkg/dockerregistry/server/manifesthandler/doc.go
@@ -1,0 +1,2 @@
+// Package manifesthandler defines a common set of operations on all versions of manifest schema.
+package manifesthandler

--- a/pkg/dockerregistry/server/manifesthandler/error.go
+++ b/pkg/dockerregistry/server/manifesthandler/error.go
@@ -1,0 +1,21 @@
+package manifesthandler
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/digest"
+)
+
+// ErrManifestBlobBadSize is returned when the blob size in a manifest does
+// not match the actual size. The docker/distribution does not check this and
+// therefore does not provide an error for this.
+type ErrManifestBlobBadSize struct {
+	Digest         digest.Digest
+	ActualSize     int64
+	SizeInManifest int64
+}
+
+func (err ErrManifestBlobBadSize) Error() string {
+	return fmt.Sprintf("the blob %s has the size (%d) different from the one specified in the manifest (%d)",
+		err.Digest, err.ActualSize, err.SizeInManifest)
+}

--- a/pkg/dockerregistry/server/manifesthandler/manifesthandler.go
+++ b/pkg/dockerregistry/server/manifesthandler/manifesthandler.go
@@ -1,4 +1,4 @@
-package server
+package manifesthandler
 
 import (
 	"fmt"

--- a/pkg/dockerregistry/server/manifesthandler/manifestschema1handler.go
+++ b/pkg/dockerregistry/server/manifesthandler/manifestschema1handler.go
@@ -1,4 +1,4 @@
-package server
+package manifesthandler
 
 import (
 	"fmt"

--- a/pkg/dockerregistry/server/manifesthandler/manifestschema2handler.go
+++ b/pkg/dockerregistry/server/manifesthandler/manifestschema2handler.go
@@ -1,4 +1,4 @@
-package server
+package manifesthandler
 
 import (
 	"errors"

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -17,23 +17,10 @@ import (
 
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/cache"
 	registrymanifest "github.com/openshift/image-registry/pkg/dockerregistry/server/manifest"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/manifesthandler"
 	"github.com/openshift/image-registry/pkg/imagestream"
 	imageapi "github.com/openshift/image-registry/pkg/origin-common/image/apis/image"
 )
-
-// ErrManifestBlobBadSize is returned when the blob size in a manifest does
-// not match the actual size. The docker/distribution does not check this and
-// therefore does not provide an error for this.
-type ErrManifestBlobBadSize struct {
-	Digest         digest.Digest
-	ActualSize     int64
-	SizeInManifest int64
-}
-
-func (err ErrManifestBlobBadSize) Error() string {
-	return fmt.Sprintf("the blob %s has the size (%d) different from the one specified in the manifest (%d)",
-		err.Digest, err.ActualSize, err.SizeInManifest)
-}
 
 var _ distribution.ManifestService = &manifestService{}
 
@@ -107,7 +94,7 @@ func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options .
 func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Put")
 
-	mh, err := NewManifestHandler(m.serverAddr, m.blobStore, manifest)
+	mh, err := manifesthandler.NewManifestHandler(m.serverAddr, m.blobStore, manifest)
 	if err != nil {
 		return "", regapi.ErrorCodeManifestInvalid.WithDetail(err)
 	}

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -40,7 +40,7 @@ type manifestService struct {
 func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Exists")
 
-	image, _, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
+	image, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
 	if err != nil {
 		return false, err
 	}
@@ -51,7 +51,7 @@ func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool,
 func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Get")
 
-	image, _, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
+	image, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerregistry/server/prune/doc.go
+++ b/pkg/dockerregistry/server/prune/doc.go
@@ -1,0 +1,45 @@
+// Package prune contains functions that allow you to manipulate data on the storage.
+//
+// OVERVIEW
+//
+// Since the registry server stores metadata in the etcd database, there are situations
+// of the desynchronization of the database and the registry storage.
+//
+// 1. If the data is removed from the etcd database, but not removed from the storage,
+// this leads to a waste of space in the storage. At the moment, the hard pruning
+// can help with this problem if you do not need the blobs anymore.
+//
+// 2. If the data is removed from the registry storage, but not removed from etcd database,
+// this leads us to broken cluster. The images that are managed by registry can not be used.
+// In some of these situations the best thing we can do is provide a tool which reports on
+// what images are broken so the user can attempt to recover their system. In other cases,
+// we can restore the data in the etcd database based on data from the storage.
+//
+// HARD PRUNE
+//
+// This mode allows you to delete blobs that are no longer referenced in the etcd
+// database (garbage) from storage and reduce the used space on the storage.
+//
+// RECOVERY
+//
+// This mode is opposite to the HARD PRUNE. In this mode, we try to restore metadata
+// from the data on the storage. There are two modes of this: check and check+recover.
+//
+// This mode covers the following cases:
+//
+// 1. Show broken imagestream tags that refer to non-existent images on the storage.
+// In this case, you can either delete such a tag, or re-push the image pointed to by this tag.
+//
+// 2. Show broken images that refer to non-existent blobs on the storage.  In this case,
+// you can re-push any imagestream tag that point to this image. Since the images are global,
+// it's enough to re-push only one image to fix all the imagestream tags that refer to it.
+//
+// 3. Show and restore either entire imagestreams or individual imagestream tags inside it
+// that exists on the storage, but removed from etcd database. Tag names will look
+// like: lost-found-<IMAGE-DIGEST> because the name of the tag is not stored on the storage
+// and can't be restored. You can make a new tag with a different name.
+//
+// Note: labels and anotations that were assigned on the image or imagestream will not be
+// restored because they were stored only in the etcd database, but not on the storage.
+//
+package prune

--- a/pkg/dockerregistry/server/prune/prune.go
+++ b/pkg/dockerregistry/server/prune/prune.go
@@ -174,7 +174,7 @@ type Summary struct {
 func Prune(ctx context.Context, registry distribution.Namespace, registryClient client.RegistryClient, pruner Pruner) (Summary, error) {
 	logger := context.GetLogger(ctx)
 
-	enumStorage := regstorage.Enumerator{registry}
+	enumStorage := regstorage.Enumerator{Registry: registry}
 
 	oc, err := registryClient.Client()
 	if err != nil {

--- a/pkg/dockerregistry/server/prune/restore.go
+++ b/pkg/dockerregistry/server/prune/restore.go
@@ -1,0 +1,380 @@
+package prune
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/storage/driver"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dockerapiv10 "github.com/openshift/api/image/docker10"
+	imageapiv1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/manifesthandler"
+	regstorage "github.com/openshift/image-registry/pkg/dockerregistry/server/storage"
+	"github.com/openshift/image-registry/pkg/imagestream"
+	imageapi "github.com/openshift/image-registry/pkg/origin-common/image/apis/image"
+	originutil "github.com/openshift/image-registry/pkg/origin-common/util"
+)
+
+// Restore defines a common set of operations for database and storage validation
+type Restore interface {
+	BrokenImage(image imageapiv1.Image, err error) error
+	BrokenImageStreamTag(is imageapiv1.ImageStream, tag imageapiv1.NamedTagEventList, pos int, err error) error
+	ImageStreamTag(imageStream imagestream.ImageStream, image *imageapiv1.Image, tagName string) error
+}
+
+// DryRunRestore prints information about each object
+type DryRunRestore struct{}
+
+var _ Restore = &DryRunRestore{}
+
+func (r *DryRunRestore) BrokenImage(image imageapiv1.Image, err error) error {
+	fmt.Printf("Broken image %q: %s\n", image.Name, err)
+	return nil
+}
+
+// BrokenImageStreamTag prints information about broken imagestream tag
+func (r *DryRunRestore) BrokenImageStreamTag(is imageapiv1.ImageStream, event imageapiv1.NamedTagEventList, pos int, err error) error {
+	ref := is.Namespace + "/" + is.Name + ":" + event.Tag
+	dgst := digest.Digest(event.Items[pos].Image)
+
+	if imgErr, ok := err.(*ErrImage); ok {
+		if imgErr.Digest == dgst {
+			fmt.Printf("Broken imagestream tag %q in position %d: image %q: %s\n", ref, pos, imgErr.Digest, err)
+		} else {
+			fmt.Printf("Broken imagestream tag %q in position %d: image blob %q: %s\n", ref, pos, imgErr.Digest, err)
+		}
+	} else {
+		fmt.Printf("Broken imagestream tag %q in position %d: %s\n", ref, pos, err)
+	}
+	return nil
+}
+
+// ImageStreamTag prints information about imagestream tag which could be restored
+func (r *DryRunRestore) ImageStreamTag(imageStream imagestream.ImageStream, image *imageapiv1.Image, tagName string) error {
+	fmt.Printf("Would add image %q to imagestream %q with tag %q\n", image.Name, imageStream.Reference(), tagName)
+	return nil
+}
+
+type StorageRestore struct {
+	DryRunRestore
+
+	Ctx    context.Context
+	Client client.Interface
+}
+
+var _ Restore = &StorageRestore{}
+
+func (r *StorageRestore) ImageStreamTag(imageStream imagestream.ImageStream, image *imageapiv1.Image, tagName string) error {
+	return imageStream.CreateImageStreamMapping(r.Ctx, r.Client, tagName, image)
+}
+
+type statter struct {
+	mu      sync.Mutex
+	statter distribution.BlobStatter
+	cache   map[digest.Digest]bool
+}
+
+func (s *statter) exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cache == nil {
+		s.cache = make(map[digest.Digest]bool)
+	}
+
+	if v, ok := s.cache[dgst]; ok {
+		return v, nil
+	}
+
+	_, err := s.statter.Stat(ctx, dgst)
+
+	if err != nil && err != distribution.ErrBlobUnknown {
+		return false, err
+	}
+
+	s.cache[dgst] = err == nil
+
+	return s.cache[dgst], nil
+}
+
+// ErrImage defines the error associated with the digest
+type ErrImage struct {
+	Digest  digest.Digest
+	Problem error
+}
+
+// Error implements the error interface
+func (err ErrImage) Error() string {
+	return err.Problem.Error()
+}
+
+// Fsck validates or recovers database based on storage
+type Fsck struct {
+	Ctx        context.Context
+	Client     client.Interface
+	Registry   distribution.Namespace
+	ServerAddr string
+	Restore    Restore
+}
+
+func (r *Fsck) checkImage(image *imageapiv1.Image, blobStatter *statter) error {
+	if !imagestream.IsImageManaged(image) {
+		return nil
+	}
+
+	if err := originutil.ImageWithMetadata(image); err != nil {
+		return fmt.Errorf("error getting image metadata: %s", err)
+	}
+
+	imageDigest, err := digest.ParseDigest(image.Name)
+	if err != nil {
+		return fmt.Errorf("bad image name %q: %s", image.Name, err)
+	}
+
+	exists, err := blobStatter.exists(r.Ctx, imageDigest)
+	if err != nil {
+		return err
+	} else if !exists {
+		return &ErrImage{
+			Digest:  imageDigest,
+			Problem: distribution.ErrBlobUnknown,
+		}
+	}
+
+	if image.DockerImageManifestMediaType == schema2.MediaTypeManifest {
+		meta, ok := image.DockerImageMetadata.Object.(*dockerapiv10.DockerImage)
+		if ok {
+			configDigest, err := digest.ParseDigest(meta.ID)
+			if err != nil {
+				return fmt.Errorf("image %q: bad config %q: %s", imageDigest, meta.ID, err)
+			}
+
+			exists, err := blobStatter.exists(r.Ctx, configDigest)
+			if err != nil {
+				return fmt.Errorf("image %q: config %q: %s", imageDigest, configDigest, err)
+			} else if !exists {
+				return &ErrImage{
+					Digest:  configDigest,
+					Problem: distribution.ErrBlobUnknown,
+				}
+			}
+		}
+	}
+
+	for _, layer := range image.DockerImageLayers {
+		layerDigest, err := digest.ParseDigest(layer.Name)
+		if err != nil {
+			return fmt.Errorf("image %q: bad layer %q: %s", imageDigest, layer.Name, err)
+		}
+
+		exists, err := blobStatter.exists(r.Ctx, layerDigest)
+		if err != nil {
+			return fmt.Errorf("image %q: layer %q: %s", imageDigest, layer.Name, err)
+		} else if !exists {
+			return &ErrImage{
+				Digest:  layerDigest,
+				Problem: distribution.ErrBlobUnknown,
+			}
+		}
+	}
+
+	return nil
+}
+
+// Database checks metadata in the database
+func (r *Fsck) Database(namespace string) error {
+	listIS, err := r.Client.ImageStreams(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		if namespace == metav1.NamespaceAll {
+			namespace = "all"
+		}
+		return fmt.Errorf("failed to list image streams in the %s namespace(s): %s", namespace, err)
+	}
+
+	var image *imageapiv1.Image
+	checkedImages := make(map[string]struct{})
+
+	for _, is := range listIS.Items {
+		stat := &statter{
+			statter: r.Registry.BlobStatter(),
+		}
+
+		for _, tagEventList := range is.Status.Tags {
+			for i, tagEvent := range tagEventList.Items {
+				if _, ok := checkedImages[tagEvent.Image]; ok {
+					continue
+				}
+				checkedImages[tagEvent.Image] = struct{}{}
+
+				imageDigest, err := digest.ParseDigest(tagEvent.Image)
+				if err == nil {
+					image, err = r.Client.Images().Get(imageDigest.String(), metav1.GetOptions{})
+					if err != nil {
+						return &ErrImage{
+							Digest:  imageDigest,
+							Problem: err,
+						}
+					}
+					err = r.checkImage(image, stat)
+					if err == nil {
+						continue
+					}
+				} else {
+					err = fmt.Errorf("bad image name %q: %s", tagEvent.Image, err)
+				}
+
+				if handlerErr := r.Restore.BrokenImageStreamTag(is, tagEventList, i, err); handlerErr != nil {
+					return handlerErr
+				}
+			}
+		}
+	}
+
+	listImages, err := r.Client.Images().List(metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list all images: %s", err)
+	}
+
+	for _, image := range listImages.Items {
+		if _, ok := checkedImages[image.Name]; ok {
+			continue
+		}
+
+		stat := &statter{
+			statter: r.Registry.BlobStatter(),
+		}
+
+		err = r.checkImage(&image, stat)
+		if err == nil {
+			continue
+		}
+
+		err = r.Restore.BrokenImage(image, err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Storage restores metadata based on the storage
+func (r *Fsck) Storage(namespace string) error {
+	logger := context.GetLogger(r.Ctx)
+	enumStorage := regstorage.Enumerator{Registry: r.Registry}
+
+	err := enumStorage.Repositories(r.Ctx, func(repoName string) error {
+		named, err := reference.WithName(repoName)
+		if err != nil {
+			logger.Errorf("failed to parse the repo name %s: %s", repoName, err)
+			return nil
+		}
+
+		ref, err := imageapi.ParseDockerImageReference(repoName)
+		if err != nil {
+			logger.Errorf("failed to parse the image reference %s: %s", repoName, err)
+			return nil
+		}
+
+		if namespace != metav1.NamespaceAll && namespace != ref.Namespace {
+			return nil
+		}
+
+		repository, err := r.Registry.Repository(r.Ctx, named)
+		if err != nil {
+			return fmt.Errorf("failed to open repository: %s: %s", repoName, err)
+		}
+
+		manifestService, err := repository.Manifests(r.Ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create manifest service: %s: %s", repoName, err)
+		}
+
+		blobStore := repository.Blobs(r.Ctx)
+
+		imageStream := imagestream.New(r.Ctx, ref.Namespace, ref.Name, r.Client)
+
+		err = enumStorage.Manifests(r.Ctx, repoName, func(dgst digest.Digest) error {
+			if _, err := imageStream.ResolveImageID(r.Ctx, dgst); err == nil {
+				return nil
+			}
+
+			manifest, err := manifestService.Get(r.Ctx, dgst)
+			if err != nil {
+				logger.Errorf("unable to fetch a manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			mh, err := manifesthandler.NewManifestHandler(r.ServerAddr, blobStore, manifest)
+			if err != nil {
+				logger.Errorf("bad manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			if err := mh.Verify(r.Ctx, false); err != nil {
+				logger.Errorf("invalid manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			config, err := mh.Config(r.Ctx)
+			if err != nil {
+				logger.Errorf("unable to get a config for manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			mediaType, payload, _, err := mh.Payload()
+			if err != nil {
+				logger.Errorf("unable to get a payload of manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			layerOrder, layers, err := mh.Layers(r.Ctx)
+			if err != nil {
+				logger.Errorf("unable to get a layers of manifest %s in the %s repository: %s", dgst, repoName, err)
+				return nil
+			}
+
+			image := &imageapiv1.Image{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: dgst.String(),
+					Annotations: map[string]string{
+						imageapi.ManagedByOpenShiftAnnotation:      "true",
+						imageapi.ImageManifestBlobStoredAnnotation: "true",
+						imageapi.DockerImageLayersOrderAnnotation:  layerOrder,
+					},
+				},
+				DockerImageReference:         fmt.Sprintf("%s/%s@%s", r.ServerAddr, repoName, dgst.String()),
+				DockerImageManifest:          string(payload),
+				DockerImageManifestMediaType: mediaType,
+				DockerImageConfig:            string(config),
+				DockerImageLayers:            layers,
+			}
+
+			return r.Restore.ImageStreamTag(imageStream, image, "lost-found-"+dgst.Hex())
+		})
+		if _, ok := err.(driver.PathNotFoundError); ok {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to restore images in the image stream %s: %s", repoName, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		switch err := err.(type) {
+		case driver.PathNotFoundError:
+			return nil
+		default:
+			return fmt.Errorf("unable to list repositories: %s", err)
+		}
+	}
+	return nil
+}

--- a/pkg/dockerregistry/server/prune/restore.go
+++ b/pkg/dockerregistry/server/prune/restore.go
@@ -196,7 +196,7 @@ func (r *Fsck) Database(namespace string) error {
 		if namespace == metav1.NamespaceAll {
 			namespace = "all"
 		}
-		return fmt.Errorf("failed to list image streams in the %s namespace(s): %s", namespace, err)
+		return fmt.Errorf("failed to list image streams in namespace(s): %s, error: %s", namespace, err)
 	}
 
 	var image *imageapiv1.Image

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -41,7 +41,7 @@ func (m *pullthroughManifestService) Get(ctx context.Context, dgst digest.Digest
 
 func (m *pullthroughManifestService) remoteGet(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	context.GetLogger(ctx).Debugf("(*pullthroughManifestService).remoteGet: starting with dgst=%s", dgst.String())
-	image, _, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
+	image, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerregistry/server/storage/storage.go
+++ b/pkg/dockerregistry/server/storage/storage.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
+)
+
+type Enumerator struct {
+	Registry distribution.Namespace
+}
+
+func (e *Enumerator) Repositories(ctx context.Context, handler func(string) error) error {
+	repositoryEnumerator, ok := e.Registry.(distribution.RepositoryEnumerator)
+	if !ok {
+		return fmt.Errorf("unable to convert Namespace to RepositoryEnumerator")
+	}
+	return repositoryEnumerator.Enumerate(ctx, handler)
+}
+
+func (e *Enumerator) Blobs(ctx context.Context, handler func(digest.Digest) error) error {
+	return e.Registry.Blobs().Enumerate(ctx, handler)
+}
+
+func (e *Enumerator) Manifests(ctx context.Context, repoName string, handler func(digest.Digest) error) error {
+	named, err := reference.WithName(repoName)
+	if err != nil {
+		return fmt.Errorf("failed to parse the repo name %s: %v", repoName, err)
+	}
+
+	repository, err := e.Registry.Repository(ctx, named)
+	if err != nil {
+		return err
+	}
+
+	manifestService, err := repository.Manifests(ctx)
+	if err != nil {
+		return err
+	}
+
+	manifestEnumerator, ok := manifestService.(distribution.ManifestEnumerator)
+	if !ok {
+		return fmt.Errorf("unable to convert ManifestService into ManifestEnumerator")
+	}
+
+	return manifestEnumerator.Enumerate(ctx, handler)
+}

--- a/pkg/dockerregistry/server/tagservice.go
+++ b/pkg/dockerregistry/server/tagservice.go
@@ -34,7 +34,7 @@ func (t tagService) Get(ctx context.Context, tag string) (distribution.Descripto
 	}
 
 	if !t.pullthroughEnabled {
-		image, _, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
+		image, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
 		if err != nil {
 			return distribution.Descriptor{}, err
 		}
@@ -71,7 +71,7 @@ func (t tagService) All(ctx context.Context) ([]string, error) {
 
 		managed, found := managedImages[dgst.String()]
 		if !found {
-			image, _, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
+			image, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
 			if err != nil {
 				context.GetLogger(ctx).Errorf("unable to get image %s %s: %v", t.imageStream.Reference(), dgst.String(), err)
 				continue
@@ -117,7 +117,7 @@ func (t tagService) Lookup(ctx context.Context, desc distribution.Descriptor) ([
 
 		managed, found := managedImages[dgst.String()]
 		if !found {
-			image, _, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
+			image, err := t.imageStream.GetImageOfImageStream(ctx, dgst)
 			if err != nil {
 				context.GetLogger(ctx).Errorf("unable to get image %s %s: %v", t.imageStream.Reference(), dgst.String(), err)
 				continue


### PR DESCRIPTION
[x] Find broken imagestream tags that reference non-existent objects in the storage.
[x] Find broken images that reference non-existent objects in the storage.
[x] Restore imagestream based on the storage data.
[x] Restore imagestream tag (not tagname) based on the storage data.

These options require:
```
oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:default:registry
```
