### PR TITLE
Handle errors without Details

### DIFF
--- a/pkg/imagestream/imagestream.go
+++ b/pkg/imagestream/imagestream.go
@@ -329,8 +329,15 @@ func (is *imageStream) CreateImageStreamMapping(ctx context.Context, userClient 
 		}
 
 		status := statusErr.ErrStatus
-		kind := strings.ToLower(status.Details.Kind)
-		isValidKind := kind == "imagestream" /*pre-1.2*/ || kind == "imagestreams" /*1.2 to 1.6*/ || kind == "imagestreammappings" /*1.7+*/
+		isValidKind := false
+		if status.Details != nil {
+			switch strings.ToLower(status.Details.Kind) {
+			case "imagestream", /*pre-1.2*/
+				"imagestreams", /*1.2 to 1.6*/
+				"imagestreammappings" /*1.7+*/ :
+				isValidKind = true
+			}
+		}
 		if !isValidKind || status.Code != http.StatusNotFound || status.Details.Name != is.name {
 			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
 			return err


### PR DESCRIPTION
When the image stream becomes large enough that we cannot add any new records into it, the returned error "etcdserver: request is too large" has the nil value in the Details field.