### PR TITLE
Add pullthrough metrics

### DIFF
--- a/pkg/dockerregistry/server/metrichandler.go
+++ b/pkg/dockerregistry/server/metrichandler.go
@@ -11,7 +11,6 @@ import (
 )
 
 func RegisterMetricHandler(app *handlers.App) {
-	metrics.Register()
 	getMetricsAccess := func(r *http.Request) []auth.Access {
 		return []auth.Access{
 			{

--- a/pkg/dockerregistry/server/metrics/cache.go
+++ b/pkg/dockerregistry/server/metrics/cache.go
@@ -1,0 +1,24 @@
+package metrics
+
+// Cache provides generic metrics for caches.
+type Cache interface {
+	Request(hit bool)
+}
+
+type cache struct {
+	hitCounter  Counter
+	missCounter Counter
+}
+
+func (c *cache) Request(hit bool) {
+	if hit {
+		c.hitCounter.Inc()
+	} else {
+		c.missCounter.Inc()
+	}
+}
+
+type noopCache struct{}
+
+func (c noopCache) Request(hit bool) {
+}

--- a/pkg/dockerregistry/server/metrics/prometheus.go
+++ b/pkg/dockerregistry/server/metrics/prometheus.go
@@ -1,0 +1,83 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace = "imageregistry"
+
+	pullthroughSubsystem = "pullthrough"
+)
+
+var (
+	requestDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "request_duration_seconds",
+			Help:      "Request latency in seconds for each operation.",
+		},
+		[]string{"operation", "name"},
+	)
+
+	pullthroughBlobstoreCacheRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: pullthroughSubsystem,
+			Name:      "blobstore_cache_requests_total",
+			Help:      "Total number of requests to the BlobStore cache.",
+		},
+		[]string{"type"},
+	)
+	pullthroughRepositoryDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: pullthroughSubsystem,
+			Name:      "repository_duration_seconds",
+			Help:      "Latency of operations with remote registries in seconds.",
+		},
+		[]string{"registry", "operation"},
+	)
+	pullthroughRepositoryErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: pullthroughSubsystem,
+			Name:      "repository_errors_total",
+			Help:      "Cumulative number of failed operations with remote registries.",
+		},
+		[]string{"registry", "operation", "code"},
+	)
+)
+
+var prometheusOnce sync.Once
+
+type prometheusSink struct{}
+
+// NewPrometheusSink returns a sink for exposing Prometheus metrics.
+func NewPrometheusSink() Sink {
+	prometheusOnce.Do(func() {
+		prometheus.MustRegister(requestDurationSeconds)
+		prometheus.MustRegister(pullthroughBlobstoreCacheRequestsTotal)
+		prometheus.MustRegister(pullthroughRepositoryDurationSeconds)
+		prometheus.MustRegister(pullthroughRepositoryErrorsTotal)
+	})
+	return prometheusSink{}
+}
+
+func (s prometheusSink) RequestDuration(funcname, reponame string) Observer {
+	return requestDurationSeconds.WithLabelValues(funcname, reponame)
+}
+
+func (s prometheusSink) PullthroughBlobstoreCacheRequests(resultType string) Counter {
+	return pullthroughBlobstoreCacheRequestsTotal.WithLabelValues(resultType)
+}
+
+func (s prometheusSink) PullthroughRepositoryDuration(registry, funcname string) Observer {
+	return pullthroughRepositoryDurationSeconds.WithLabelValues(registry, funcname)
+}
+
+func (s prometheusSink) PullthroughRepositoryErrors(registry, funcname, errcode string) Counter {
+	return pullthroughRepositoryErrorsTotal.WithLabelValues(registry, funcname, errcode)
+}

--- a/pkg/dockerregistry/server/metrics/testing/counter.go
+++ b/pkg/dockerregistry/server/metrics/testing/counter.go
@@ -1,0 +1,55 @@
+package testing
+
+import (
+	"fmt"
+
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/metrics"
+	"github.com/openshift/image-registry/pkg/testutil/counter"
+)
+
+type callbackObserver func(float64)
+
+func (f callbackObserver) Observe(value float64) {
+	f(value)
+}
+
+type callbackCounter func()
+
+func (f callbackCounter) Inc() {
+	f()
+}
+
+type counterSink struct {
+	c counter.Counter
+}
+
+var _ metrics.Sink = &counterSink{}
+
+func (s counterSink) RequestDuration(funcname, reponame string) metrics.Observer {
+	return callbackObserver(func(float64) {
+		s.c.Add(fmt.Sprintf("request:%s:%s", funcname, reponame), 1)
+	})
+}
+
+func (s counterSink) PullthroughBlobstoreCacheRequests(resultType string) metrics.Counter {
+	return callbackCounter(func() {
+		s.c.Add(fmt.Sprintf("pullthrough_blobstore_cache_requests:%s", resultType), 1)
+	})
+}
+
+func (s counterSink) PullthroughRepositoryDuration(registry, funcname string) metrics.Observer {
+	return callbackObserver(func(float64) {
+		s.c.Add(fmt.Sprintf("pullthrough_repository:%s:%s", registry, funcname), 1)
+	})
+}
+
+func (s counterSink) PullthroughRepositoryErrors(registry, funcname, errcode string) metrics.Counter {
+	return callbackCounter(func() {
+		s.c.Add(fmt.Sprintf("pullthrough_repository_errors:%s:%s:%s", registry, funcname, errcode), 1)
+	})
+}
+
+func NewCounterSink() (counter.Counter, metrics.Sink) {
+	c := counter.New()
+	return c, counterSink{c: c}
+}

--- a/pkg/dockerregistry/server/metrics/timer.go
+++ b/pkg/dockerregistry/server/metrics/timer.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"time"
+)
+
+// Timer is a helper type to time functions.
+type Timer interface {
+	// Stop records the duration passed since the Timer was created with NewTimer.
+	Stop()
+}
+
+// NewTimer wraps the HistogramVec and used to track amount of time passed since the Timer was created.
+func NewTimer(observer Observer) Timer {
+	return &timer{
+		observer:  observer,
+		startTime: time.Now(),
+	}
+}
+
+type timer struct {
+	observer  Observer
+	startTime time.Time
+}
+
+func (t *timer) Stop() {
+	t.observer.Observe(time.Since(t.startTime).Seconds())
+}

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/digest"
 
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/cache"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/metrics"
 	"github.com/openshift/image-registry/pkg/errors"
 	"github.com/openshift/image-registry/pkg/imagestream"
 	imageapi "github.com/openshift/image-registry/pkg/origin-common/image/apis/image"
@@ -24,6 +25,7 @@ type pullthroughManifestService struct {
 	cache                   cache.RepositoryDigest
 	mirror                  bool
 	registryAddr            string
+	metrics                 metrics.Pullthrough
 }
 
 var _ distribution.ManifestService = &pullthroughManifestService{}
@@ -98,7 +100,7 @@ func (m *pullthroughManifestService) mirrorManifest(ctx context.Context, manifes
 }
 
 func (m *pullthroughManifestService) getRemoteRepositoryClient(ctx context.Context, ref *imageapi.DockerImageReference, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Repository, error) {
-	retriever := getImportContext(ctx, m.imageStream.GetSecrets)
+	retriever := getImportContext(ctx, m.imageStream.GetSecrets, m.metrics)
 
 	// determine, whether to fall-back to insecure transport based on a specification of image's tag
 	// if the client pulls by tag, use that

--- a/pkg/dockerregistry/server/registry_test.go
+++ b/pkg/dockerregistry/server/registry_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
 	registryclient "github.com/openshift/image-registry/pkg/dockerregistry/server/client"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/metrics"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/supermiddleware"
 )
 
@@ -68,6 +69,7 @@ func newTestRegistry(
 		quotaEnforcing: &quotaEnforcingConfig{
 			enforcementEnabled: false,
 		},
+		metrics: metrics.NewNoopMetrics(),
 	}
 
 	if storageDriver == nil {

--- a/pkg/dockerregistry/server/remoteblobgetter.go
+++ b/pkg/dockerregistry/server/remoteblobgetter.go
@@ -77,18 +77,15 @@ func NewBlobGetterService(
 	}
 }
 
-// Stat provides metadata about a blob identified by the digest. If the
-// blob is unknown to the describer, ErrBlobUnknown will be returned.
-func (rbgs *remoteBlobGetterService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
-	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).Stat: starting with dgst=%s", dgst.String())
+func (rbgs *remoteBlobGetterService) findBlobStore(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, distribution.BlobStore, error) {
 	// look up the potential remote repositories that this blob could be part of (at this time,
 	// we don't know which image in the image stream surfaced the content).
 	ok, err := rbgs.imageStream.Exists()
 	if err != nil {
-		return distribution.Descriptor{}, err
+		return distribution.Descriptor{}, nil, err
 	}
 	if !ok {
-		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		return distribution.Descriptor{}, nil, distribution.ErrBlobUnknown
 	}
 
 	cached, _ := rbgs.cache.Repositories(dgst)
@@ -98,67 +95,88 @@ func (rbgs *remoteBlobGetterService) Stat(ctx context.Context, dgst digest.Diges
 	// look at the first level of tagged repositories first
 	repositoryCandidates, search, err := rbgs.imageStream.IdentifyCandidateRepositories(true)
 	if err != nil {
-		return distribution.Descriptor{}, err
+		return distribution.Descriptor{}, nil, err
 	}
-	if desc, err := rbgs.findCandidateRepository(ctx, repositoryCandidates, search, cached, dgst, retriever); err == nil {
-		return desc, nil
+	if desc, bs, err := rbgs.findCandidateRepository(ctx, repositoryCandidates, search, cached, dgst, retriever); err == nil {
+		return desc, bs, nil
 	}
 
 	// look at all other repositories tagged by the server
 	repositoryCandidates, secondary, err := rbgs.imageStream.IdentifyCandidateRepositories(false)
 	if err != nil {
-		return distribution.Descriptor{}, err
+		return distribution.Descriptor{}, nil, err
 	}
 	for k := range search {
 		delete(secondary, k)
 	}
-	if desc, err := rbgs.findCandidateRepository(ctx, repositoryCandidates, secondary, cached, dgst, retriever); err == nil {
-		return desc, nil
+	if desc, bs, err := rbgs.findCandidateRepository(ctx, repositoryCandidates, secondary, cached, dgst, retriever); err == nil {
+		return desc, bs, nil
 	}
 
-	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	return distribution.Descriptor{}, nil, distribution.ErrBlobUnknown
+}
+
+// Stat provides metadata about a blob identified by the digest. If the
+// blob is unknown to the describer, ErrBlobUnknown will be returned.
+func (rbgs *remoteBlobGetterService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).Stat: starting with dgst=%s", dgst)
+
+	bs, ok := rbgs.digestToStore.Get(dgst)
+	if ok {
+		desc, err := bs.Stat(ctx, dgst)
+		if err == nil {
+			return desc, nil
+		}
+
+		context.GetLogger(ctx).Warnf("Stat: failed to stat blob %s in cached remote repository: %v", dgst, err)
+
+		// There are two possible scenarios:
+		//
+		//   * the blob is no longer available on the remote server,
+		//   * the registry isn't available at the moment.
+		//
+		// In both cases we can move on and hopefully we'll find another
+		// registry.
+	}
+
+	desc, bs, err := rbgs.findBlobStore(ctx, dgst)
+	if err != nil {
+		return desc, err
+	}
+
+	rbgs.digestToStore.Put(dgst, bs)
+
+	return desc, nil
 }
 
 func (rbgs *remoteBlobGetterService) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
-	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).Open: starting with dgst=%s", dgst.String())
-	store, ok := rbgs.digestToStore.Get(dgst)
-	if ok {
-		return store.Open(ctx, dgst)
-	}
-
-	desc, err := rbgs.Stat(ctx, dgst)
-	if err != nil {
-		context.GetLogger(ctx).Errorf("Open: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
-		return nil, err
-	}
-
-	store, ok = rbgs.digestToStore.Get(desc.Digest)
+	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).Open: starting with dgst=%s", dgst)
+	bs, ok := rbgs.digestToStore.Get(dgst)
 	if !ok {
-		return nil, distribution.ErrBlobUnknown
+		var err error
+		_, bs, err = rbgs.findBlobStore(ctx, dgst)
+		if err != nil {
+			return nil, err
+		}
+		rbgs.digestToStore.Put(dgst, bs)
 	}
 
-	return store.Open(ctx, desc.Digest)
+	return bs.Open(ctx, dgst)
 }
 
 func (rbgs *remoteBlobGetterService) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
-	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).ServeBlob: starting with dgst=%s", dgst.String())
-	store, ok := rbgs.digestToStore.Get(dgst)
-	if ok {
-		return store.ServeBlob(ctx, w, req, dgst)
-	}
-
-	desc, err := rbgs.Stat(ctx, dgst)
-	if err != nil {
-		context.GetLogger(ctx).Errorf("ServeBlob: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
-		return err
-	}
-
-	store, ok = rbgs.digestToStore.Get(desc.Digest)
+	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).ServeBlob: starting with dgst=%s", dgst)
+	bs, ok := rbgs.digestToStore.Get(dgst)
 	if !ok {
-		return distribution.ErrBlobUnknown
+		var err error
+		_, bs, err = rbgs.findBlobStore(ctx, dgst)
+		if err != nil {
+			return err
+		}
+		rbgs.digestToStore.Put(dgst, bs)
 	}
 
-	return store.ServeBlob(ctx, w, req, desc.Digest)
+	return bs.ServeBlob(ctx, w, req, dgst)
 }
 
 // proxyStat attempts to locate the digest in the provided remote repository or returns an error. If the digest is found,
@@ -168,7 +186,7 @@ func (rbgs *remoteBlobGetterService) proxyStat(
 	retriever registryclient.RepositoryRetriever,
 	spec *imagestream.ImagePullthroughSpec,
 	dgst digest.Digest,
-) (distribution.Descriptor, error) {
+) (distribution.Descriptor, distribution.BlobStore, error) {
 	ref := spec.DockerImageReference
 	insecureNote := ""
 	if spec.Insecure {
@@ -178,7 +196,7 @@ func (rbgs *remoteBlobGetterService) proxyStat(
 	repo, err := retriever.Repository(ctx, ref.RegistryURL(), ref.RepositoryName(), spec.Insecure)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("Error getting remote repository for image %q: %v", ref.AsRepository().Exact(), err)
-		return distribution.Descriptor{}, err
+		return distribution.Descriptor{}, nil, err
 	}
 
 	pullthroughBlobStore := repo.Blobs(ctx)
@@ -187,33 +205,26 @@ func (rbgs *remoteBlobGetterService) proxyStat(
 		if err != distribution.ErrBlobUnknown {
 			context.GetLogger(ctx).Errorf("Error statting blob %s in remote repository %q: %v", dgst, ref.AsRepository().Exact(), err)
 		}
-		return distribution.Descriptor{}, err
+		return distribution.Descriptor{}, nil, err
 	}
 
-	rbgs.digestToStore.Put(dgst, pullthroughBlobStore)
-	return desc, nil
+	return desc, pullthroughBlobStore, nil
 }
 
 // Get attempts to fetch the requested blob by digest using a remote proxy store if necessary.
 func (rbgs *remoteBlobGetterService) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
 	context.GetLogger(ctx).Debugf("(*remoteBlobGetterService).Get: starting with dgst=%s", dgst.String())
-	store, ok := rbgs.digestToStore.Get(dgst)
-	if ok {
-		return store.Get(ctx, dgst)
-	}
-
-	desc, err := rbgs.Stat(ctx, dgst)
-	if err != nil {
-		context.GetLogger(ctx).Errorf("Get: failed to stat blob %q in remote repositories: %v", dgst.String(), err)
-		return nil, err
-	}
-
-	store, ok = rbgs.digestToStore.Get(desc.Digest)
+	bs, ok := rbgs.digestToStore.Get(dgst)
 	if !ok {
-		return nil, distribution.ErrBlobUnknown
+		var err error
+		_, bs, err = rbgs.findBlobStore(ctx, dgst)
+		if err != nil {
+			return nil, err
+		}
+		rbgs.digestToStore.Put(dgst, bs)
 	}
 
-	return store.Get(ctx, desc.Digest)
+	return bs.Get(ctx, dgst)
 }
 
 // findCandidateRepository looks in search for a particular blob, referring to previously cached items
@@ -224,10 +235,10 @@ func (rbgs *remoteBlobGetterService) findCandidateRepository(
 	cachedRepos []string,
 	dgst digest.Digest,
 	retriever registryclient.RepositoryRetriever,
-) (distribution.Descriptor, error) {
+) (distribution.Descriptor, distribution.BlobStore, error) {
 	// no possible remote locations to search, exit early
 	if len(search) == 0 {
-		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+		return distribution.Descriptor{}, nil, distribution.ErrBlobUnknown
 	}
 
 	// see if any of the previously located repositories containing this digest are in this
@@ -237,13 +248,13 @@ func (rbgs *remoteBlobGetterService) findCandidateRepository(
 		if !ok {
 			continue
 		}
-		desc, err := rbgs.proxyStat(ctx, retriever, &spec, dgst)
+		desc, bs, err := rbgs.proxyStat(ctx, retriever, &spec, dgst)
 		if err != nil {
 			delete(search, repo)
 			continue
 		}
 		context.GetLogger(ctx).Infof("Found digest location from cache %q in %q", dgst, repo)
-		return desc, nil
+		return desc, bs, nil
 	}
 
 	// search the remaining registries for this digest
@@ -252,14 +263,14 @@ func (rbgs *remoteBlobGetterService) findCandidateRepository(
 		if !ok {
 			continue
 		}
-		desc, err := rbgs.proxyStat(ctx, retriever, &spec, dgst)
+		desc, bs, err := rbgs.proxyStat(ctx, retriever, &spec, dgst)
 		if err != nil {
 			continue
 		}
 		_ = rbgs.cache.AddDigest(dgst, repo)
 		context.GetLogger(ctx).Infof("Found digest location by search %q in %q", dgst, repo)
-		return desc, nil
+		return desc, bs, nil
 	}
 
-	return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	return distribution.Descriptor{}, nil, distribution.ErrBlobUnknown
 }

--- a/pkg/testframework/registry.go
+++ b/pkg/testframework/registry.go
@@ -27,6 +27,15 @@ func (o DisableMirroring) Apply(dockerConfig *configuration.Configuration, extra
 	extraConfig.Pullthrough.Mirror = false
 }
 
+type EnableMetrics struct {
+	Secret string
+}
+
+func (o EnableMetrics) Apply(dockerConfig *configuration.Configuration, extraConfig *registryconfig.Configuration) {
+	extraConfig.Metrics.Enabled = true
+	extraConfig.Metrics.Secret = o.Secret
+}
+
 func StartTestRegistry(t *testing.T, kubeConfigPath string, options ...RegistryOption) (net.Listener, CloseFunc) {
 	localIPv4, err := DefaultLocalIP4()
 	if err != nil {

--- a/test/integration/metricspullthrough/metricspullthrough_test.go
+++ b/test/integration/metricspullthrough/metricspullthrough_test.go
@@ -1,0 +1,198 @@
+package integration
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/docker/distribution"
+	digest "github.com/docker/distribution/digest"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imageapiv1 "github.com/openshift/api/image/v1"
+	imageclientv1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+
+	"github.com/openshift/image-registry/pkg/testframework"
+)
+
+func TestPullthroughBlob(t *testing.T) {
+	config := "{}"
+	configDigest := digest.FromBytes([]byte(config))
+
+	foo := "foo"
+	fooDigest := digest.FromBytes([]byte(foo))
+
+	master := testframework.NewMaster(t)
+	defer master.Close()
+
+	testuser := master.CreateUser("testuser", "testp@ssw0rd")
+	testproject := master.CreateProject("testproject", testuser.Name)
+	teststreamName := "pullthrough"
+
+	// TODO(dmage): use atomic variable
+	remoteRegistryRequiresAuth := false
+	ts := testframework.NewHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := fmt.Sprintf("%s %s", r.Method, r.URL.Path)
+
+		t.Logf("remote registry: %s", req)
+
+		w.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+
+		if remoteRegistryRequiresAuth {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		switch req {
+		case "GET /v2/":
+			w.Write([]byte(`{}`))
+		case "GET /v2/remoteimage/manifests/latest":
+			mediaType := "application/vnd.docker.distribution.manifest.v2+json"
+			w.Header().Set("Content-Type", mediaType)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"schemaVersion": 2,
+				"mediaType":     mediaType,
+				"config": map[string]interface{}{
+					"mediaType": "application/vnd.docker.container.image.v1+json",
+					"size":      len(config),
+					"digest":    configDigest.String(),
+				},
+				"layers": []map[string]interface{}{
+					{
+						"mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+						"size":      len(foo),
+						"digest":    fooDigest.String(),
+					},
+				},
+			})
+		case "GET /v2/remoteimage/blobs/" + configDigest.String():
+			w.Write([]byte(config))
+		case "HEAD /v2/remoteimage/blobs/" + fooDigest.String():
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(foo)))
+			w.WriteHeader(http.StatusOK)
+		case "GET /v2/remoteimage/blobs/" + fooDigest.String():
+			w.Write([]byte(foo))
+		default:
+			t.Errorf("error: remote registry got unexpected request %s: %#+v", req, r)
+		}
+	}))
+	defer ts.Close()
+
+	imageClient := imageclientv1.NewForConfigOrDie(master.AdminKubeConfig())
+
+	isi, err := imageClient.ImageStreamImports(testproject.Name).Create(&imageapiv1.ImageStreamImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: teststreamName,
+		},
+		Spec: imageapiv1.ImageStreamImportSpec{
+			Import: true,
+			Images: []imageapiv1.ImageImportSpec{
+				{
+					From: corev1.ObjectReference{
+						Kind: "DockerImage",
+						Name: fmt.Sprintf("%s/remoteimage:latest", ts.URL.Host),
+					},
+					ImportPolicy: imageapiv1.TagImportPolicy{
+						Insecure: true,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	teststream, err := imageClient.ImageStreams(testproject.Name).Get(teststreamName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(teststream.Status.Tags) == 0 {
+		t.Fatalf("failed to import image: %#+v %#+v", isi, teststream)
+	}
+
+	remoteRegistryRequiresAuth = true
+
+	registry := master.StartRegistry(t, testframework.DisableMirroring{}, testframework.EnableMetrics{Secret: "MetricsSecret"})
+	defer registry.Close()
+
+	repo := registry.Repository(testproject.Name, teststream.Name, testuser)
+
+	ctx := context.Background()
+
+	_, err = repo.Blobs(ctx).Get(ctx, fooDigest)
+	if err != distribution.ErrBlobUnknown {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", registry.BaseURL()+"/extensions/v2/metrics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer MetricsSecret")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	metrics := []struct {
+		name   string
+		values []string
+	}{
+		{
+			name:   "imageregistry_pullthrough_repository_errors_total",
+			values: []string{`operation="BlobStore.Stat"`, `code="UNAUTHORIZED"`},
+		},
+		{
+			name:   "imageregistry_pullthrough_blobstore_cache_requests_total",
+			values: []string{`type="Miss"`},
+		},
+		{
+			name:   "imageregistry_pullthrough_repository_duration_seconds_bucket",
+			values: []string{`operation="Init"`},
+		},
+	}
+
+	r := bufio.NewReader(resp.Body)
+	for {
+		line, err := r.ReadString('\n')
+		line = strings.TrimRight(line, "\n")
+		t.Log(line)
+
+	metric:
+		for i, m := range metrics {
+			if !strings.HasPrefix(line, m.name+"{") {
+				continue
+			}
+			for _, v := range m.values {
+				if !strings.Contains(line, v) {
+					continue metric
+				}
+			}
+
+			// metric found, delete it
+			metrics[i] = metrics[len(metrics)-1]
+			metrics = metrics[:len(metrics)-1]
+			break
+		}
+
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("unable to find metrics: %v", metrics)
+	}
+}

--- a/test/integration/pullthroughblob/pullthroughblob_test.go
+++ b/test/integration/pullthroughblob/pullthroughblob_test.go
@@ -116,7 +116,7 @@ func TestPullthroughBlob(t *testing.T) {
 		"GET /v2/remoteimage/manifests/latest":               1,
 		"GET /v2/remoteimage/blobs/" + configDigest.String(): 1,
 	}); diff != nil {
-		t.Fatalf("unexpected count of requests: %q", diff)
+		t.Fatalf("unexpected number of requests: %q", diff)
 	}
 
 	// Reset counter
@@ -138,12 +138,12 @@ func TestPullthroughBlob(t *testing.T) {
 		t.Fatalf("got %q, want %q", string(data), foo)
 	}
 
-	// TODO(dmage): reduce number of requests
+	// TODO(dmage): remove the HEAD request
 	if diff := requestCounter.Diff(counter.M{
-		"GET /v2/": 2,
-		"HEAD /v2/remoteimage/blobs/" + fooDigest.String(): 2,
+		"GET /v2/": 1,
+		"HEAD /v2/remoteimage/blobs/" + fooDigest.String(): 1,
 		"GET /v2/remoteimage/blobs/" + fooDigest.String():  1,
 	}); diff != nil {
-		t.Fatalf("unexpected count of requests: %q", diff)
+		t.Fatalf("unexpected number of requests: %q", diff)
 	}
 }


### PR DESCRIPTION
https://trello.com/c/g3380oUO/1534-8-implement-recommended-registry-metrics-registry

New metrics:

  * imageregistry_pullthrough_blobstore_cache_requests_total{type}
  * imageregistry_pullthrough_repository_duration_seconds_bucket{registry,operation,le}
  * imageregistry_pullthrough_repository_duration_seconds_sum{registry,operation}
  * imageregistry_pullthrough_repository_duration_seconds_count{registry,operation}
  * imageregistry_pullthrough_repository_errors_total{registry,operation,code}

Cache request types:

  * Hit
  * Miss

Repository operations:

  * Init
  * BlobStore.Stat
  * BlobStore.Open
  * ManifestService.Get