### PR TITLE
Cache provider

### DIFF
--- a/pkg/dockerregistry/server/app.go
+++ b/pkg/dockerregistry/server/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
+	registrycache "github.com/docker/distribution/registry/storage/cache"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/cache"
@@ -76,6 +77,12 @@ func (app *App) BlobStatter() distribution.BlobStatter {
 		Cache: app.cache,
 		Svc:   app.registry.BlobStatter(),
 	}
+}
+
+func (app *App) CacheProvider(ctx context.Context, options map[string]interface{}) (registrycache.BlobDescriptorCacheProvider, error) {
+	return &cache.Provider{
+		Cache: app.cache,
+	}, nil
 }
 
 // NewApp configures the registry application and returns http.Handler for it.

--- a/pkg/dockerregistry/server/cache/cacheprovider.go
+++ b/pkg/dockerregistry/server/cache/cacheprovider.go
@@ -1,0 +1,81 @@
+package cache
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/storage/cache"
+)
+
+type Provider struct {
+	Cache DigestCache
+}
+
+var _ cache.BlobDescriptorCacheProvider = &Provider{}
+
+func (c *Provider) RepositoryScoped(repo string) (distribution.BlobDescriptorService, error) {
+	if _, err := reference.ParseNamed(repo); err != nil {
+		return nil, err
+	}
+	return &RepositoryScopedProvider{
+		Repo:  repo,
+		Cache: c.Cache,
+	}, nil
+}
+
+func (c *Provider) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	item, err := c.Cache.Get(dgst)
+
+	if err != nil && err != distribution.ErrBlobUnknown {
+		return distribution.Descriptor{}, err
+	}
+
+	if item.desc == nil {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
+	return *item.desc, nil
+}
+
+func (c *Provider) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	return c.Cache.Add(dgst, &DigestValue{
+		desc: &desc,
+	})
+}
+
+func (c *Provider) Clear(ctx context.Context, dgst digest.Digest) error {
+	return c.Cache.Remove(dgst)
+}
+
+type RepositoryScopedProvider struct {
+	Repo  string
+	Cache DigestCache
+}
+
+var _ distribution.BlobDescriptorService = &RepositoryScopedProvider{}
+
+func (c *RepositoryScopedProvider) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	item, err := c.Cache.Get(dgst)
+
+	if err != nil && err != distribution.ErrBlobUnknown {
+		return distribution.Descriptor{}, err
+	}
+
+	if item.desc == nil || !item.repositories.Contains(c.Repo) {
+		return distribution.Descriptor{}, distribution.ErrBlobUnknown
+	}
+
+	return *item.desc, nil
+}
+
+func (c *RepositoryScopedProvider) SetDescriptor(ctx context.Context, dgst digest.Digest, desc distribution.Descriptor) error {
+	return c.Cache.Add(dgst, &DigestValue{
+		desc: &desc,
+		repo: &c.Repo,
+	})
+}
+
+func (c *RepositoryScopedProvider) Clear(ctx context.Context, dgst digest.Digest) error {
+	return c.Cache.RemoveRepository(dgst, c.Repo)
+}

--- a/pkg/dockerregistry/server/cache/cacheprovider_test.go
+++ b/pkg/dockerregistry/server/cache/cacheprovider_test.go
@@ -1,0 +1,209 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/digest"
+)
+
+func TestGlobalProviderStat(t *testing.T) {
+	now := time.Now()
+	clock := clock.NewFakeClock(now)
+
+	cache, err := NewBlobDigest(5, 3, ttl1m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.(*BlobDigest).clock = clock
+
+	cacheprovider := &Provider{
+		Cache: cache,
+	}
+
+	_, err = cacheprovider.Stat(context.Background(), digest.Digest("sha256:foo"))
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != digest.ErrDigestInvalidFormat {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dgst := digest.Digest("sha256:4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865")
+
+	desc, err := cacheprovider.Stat(context.Background(), dgst)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = cacheprovider.SetDescriptor(context.Background(), dgst, distribution.Descriptor{
+		Digest: dgst,
+		Size:   2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	desc, err = cacheprovider.Stat(context.Background(), dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if desc.Digest != dgst {
+		t.Fatalf("unexpected descriptor: %#+v", desc)
+	}
+
+	clock.Step(ttl5m)
+
+	desc, err = cacheprovider.Stat(context.Background(), dgst)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGlobalProviderClear(t *testing.T) {
+	now := time.Now()
+	clock := clock.NewFakeClock(now)
+
+	cache, err := NewBlobDigest(5, 3, ttl1m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.(*BlobDigest).clock = clock
+
+	cacheprovider := &Provider{
+		Cache: cache,
+	}
+
+	dgst := digest.Digest("sha256:4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865")
+
+	err = cacheprovider.SetDescriptor(context.Background(), dgst, distribution.Descriptor{
+		Digest: dgst,
+		Size:   2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	desc, err := cacheprovider.Stat(context.Background(), dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if desc.Digest != dgst {
+		t.Fatalf("unexpected descriptor: %#+v", desc)
+	}
+
+	err = cacheprovider.Clear(context.Background(), dgst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = cacheprovider.Stat(context.Background(), dgst)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRepositoryScopedProviderStat(t *testing.T) {
+	now := time.Now()
+	clock := clock.NewFakeClock(now)
+
+	cache, err := NewBlobDigest(5, 3, ttl1m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache.(*BlobDigest).clock = clock
+
+	cacheprovider := &Provider{
+		Cache: cache,
+	}
+
+	repoprovider, err := cacheprovider.RepositoryScoped("foo|invalid|repository")
+	if err == nil {
+		t.Fatalf("error expected")
+	}
+
+	repoprovider, err = cacheprovider.RepositoryScoped("foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = repoprovider.Stat(context.Background(), digest.Digest("sha256:foo"))
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != digest.ErrDigestInvalidFormat {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dgst := digest.Digest("sha256:4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865")
+
+	err = repoprovider.SetDescriptor(context.Background(), dgst, distribution.Descriptor{
+		Digest: dgst,
+		Size:   2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	desc, err := cacheprovider.Stat(context.Background(), dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desc.Digest != dgst {
+		t.Fatalf("unexpected descriptor: %#+v", desc)
+	}
+
+	desc, err = repoprovider.Stat(context.Background(), dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desc.Digest != dgst {
+		t.Fatalf("unexpected descriptor: %#+v", desc)
+	}
+
+	err = repoprovider.Clear(context.Background(), dgst)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = repoprovider.Stat(context.Background(), dgst)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	desc, err = cacheprovider.Stat(context.Background(), dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if desc.Digest != dgst {
+		t.Fatalf("unexpected descriptor: %#+v", desc)
+	}
+
+	clock.Step(ttl5m)
+
+	_, err = cacheprovider.Stat(context.Background(), dgst)
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != distribution.ErrBlobUnknown {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -475,19 +475,16 @@ func migrateMiddleware(dockercfg *configuration.Configuration, cfg *Configuratio
 		}
 	}
 
-	// TODO(legion) Uncomment this when we will have our cache on the storage level.
-	/*
-		if cc, ok := dockercfg.Storage["cache"]; ok {
-			v, ok := cc["blobdescriptor"]
-			if !ok {
-				// Backwards compatible: "layerinfo" == "blobdescriptor"
-				v = cc["layerinfo"]
-			}
-			if v == "inmemory" {
-				delete(dockercfg.Storage, "cache")
-			}
+	if cc, ok := dockercfg.Storage["cache"]; ok {
+		v, ok := cc["blobdescriptor"]
+		if !ok {
+			// Backwards compatible: "layerinfo" == "blobdescriptor"
+			v = cc["layerinfo"]
 		}
-	*/
+		if v == "inmemory" {
+			dockercfg.Storage["cache"]["blobdescriptor"] = middlewareName
+		}
+	}
 
 	if cfg.Auth == nil {
 		cfg.Auth = &Auth{}

--- a/pkg/dockerregistry/server/supermiddleware/app_test.go
+++ b/pkg/dockerregistry/server/supermiddleware/app_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/auth"
+	"github.com/docker/distribution/registry/storage/cache"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	_ "github.com/docker/distribution/registry/storage/driver/inmemory"
 
@@ -108,6 +109,10 @@ func (app *testApp) Repository(ctx context.Context, repo distribution.Repository
 	return repo, bdsf, nil
 }
 
+func (app *testApp) CacheProvider(ctx context.Context, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error) {
+	return nil, nil
+}
+
 func TestApp(t *testing.T) {
 	log := &log{}
 
@@ -121,6 +126,9 @@ func TestApp(t *testing.T) {
 			"inmemory": nil,
 			"delete": configuration.Parameters{
 				"enabled": true,
+			},
+			"cache": configuration.Parameters{
+				"blobdescriptor": Name,
 			},
 		},
 		Middleware: map[string][]configuration.Middleware{

--- a/vendor/github.com/docker/distribution/registry/handlers/app.go
+++ b/vendor/github.com/docker/distribution/registry/handlers/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/distribution/registry/proxy"
 	"github.com/docker/distribution/registry/storage"
 	memorycache "github.com/docker/distribution/registry/storage/cache/memory"
+	cacheprovider "github.com/docker/distribution/registry/storage/cache/provider"
 	rediscache "github.com/docker/distribution/registry/storage/cache/redis"
 	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/factory"
@@ -276,7 +277,20 @@ func NewApp(ctx context.Context, config *configuration.Configuration) *App {
 			ctxu.GetLogger(app).Infof("using inmemory blob descriptor cache")
 		default:
 			if v != "" {
-				ctxu.GetLogger(app).Warnf("unknown cache type %q, caching disabled", config.Storage["cache"])
+				name, ok := v.(string)
+				if !ok {
+					panic(fmt.Sprintf("unexpected type of value %T (string expected)", v))
+				}
+				cacheProvider, err := cacheprovider.Get(app, name, cc)
+				if err != nil {
+					panic("unable to initialize cache provider: " + err.Error())
+				}
+				localOptions := append(options, storage.BlobDescriptorCacheProvider(cacheProvider))
+				app.registry, err = storage.NewRegistry(app, app.driver, localOptions...)
+				if err != nil {
+					panic("could not create registry: " + err.Error())
+				}
+				ctxu.GetLogger(app).Infof("using %s blob descriptor cache", name)
 			}
 		}
 	}

--- a/vendor/github.com/docker/distribution/registry/storage/cache/provider/cacheprovider.go
+++ b/vendor/github.com/docker/distribution/registry/storage/cache/provider/cacheprovider.go
@@ -1,0 +1,37 @@
+package cacheprovider
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/registry/storage/cache"
+)
+
+// InitFunc is the type of a CacheProvider factory function and is
+// used to register the constructor for different CacheProvider backends.
+type InitFunc func(ctx context.Context, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error)
+
+var cacheProviders map[string]InitFunc
+
+// Register is used to register an InitFunc for
+// a CacheProvider backend with the given name.
+func Register(name string, initFunc InitFunc) error {
+	if cacheProviders == nil {
+		cacheProviders = make(map[string]InitFunc)
+	}
+	if _, exists := cacheProviders[name]; exists {
+		return fmt.Errorf("name already registered: %s", name)
+	}
+
+	cacheProviders[name] = initFunc
+
+	return nil
+}
+
+// Get constructs a CacheProvider with the given options using the named backend.
+func Get(ctx context.Context, name string, options map[string]interface{}) (cache.BlobDescriptorCacheProvider, error) {
+	if initFunc, exists := cacheProviders[name]; exists {
+		return initFunc(ctx, options)
+	}
+	return nil, fmt.Errorf("no cache Provider registered with name: %s", name)
+}


### PR DESCRIPTION
New cache provider should join our cache and `docker/distribution` cache in one. The expiration time  now affects it. Also we can prune it.
