### PR TITLE
Registry catalog

### DIFF
--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -301,6 +301,20 @@ func (ac *AccessController) Authorized(ctx context.Context, accessRecords ...reg
 			default:
 				return nil, ac.wrapErr(ctx, ErrUnsupportedAction)
 			}
+
+		case "registry":
+			switch access.Resource.Name {
+			case "catalog":
+				if access.Action != "*" {
+					return nil, ac.wrapErr(ctx, ErrUnsupportedAction)
+				}
+				if err := verifyCatalogAccess(ctx, osClient); err != nil {
+					return nil, ac.wrapErr(ctx, err)
+				}
+			default:
+				return nil, ac.wrapErr(ctx, ErrUnsupportedResource)
+			}
+
 		default:
 			return nil, ac.wrapErr(ctx, ErrUnsupportedResource)
 		}
@@ -438,6 +452,10 @@ func verifyImageSignatureAccess(ctx context.Context, namespace, imageRepo string
 
 func verifyPruneAccess(ctx context.Context, c client.SelfSubjectAccessReviewsNamespacer) error {
 	return verifyWithGlobalSAR(ctx, "images", "", "delete", c)
+}
+
+func verifyCatalogAccess(ctx context.Context, c client.SelfSubjectAccessReviewsNamespacer) error {
+	return verifyWithGlobalSAR(ctx, "imagestreams", "", "list", c)
 }
 
 func verifyMetricsAccess(ctx context.Context, metrics configuration.Metrics, token string, c client.SelfSubjectAccessReviewsNamespacer) error {

--- a/pkg/dockerregistry/server/catalog.go
+++ b/pkg/dockerregistry/server/catalog.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/cache"
+
+	"github.com/docker/distribution/context"
+
+	imageapiv1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+)
+
+const paginationEntryTTL = time.Minute
+
+// RepositoryEnumerator allows to enumerate repositories known to the registry.
+type RepositoryEnumerator interface {
+	// EnumerateRepositories fills the given repos slice with image stream names. The slice's length
+	// determines the maximum number of repositories returned. The repositories are lexicographically sorted.
+	// The last argument allows for pagination. It is the offset in the catalog. Returned is a number of
+	// repositories filled. If there are no more repositories to return, io.EOF is returned.
+	EnumerateRepositories(ctx context.Context, repos []string, last string) (n int, err error)
+}
+
+// cachingRepositoryEnumerator is an enumerator that supports chunking by caching associations between
+// repository names and opaque continuation tokens.
+type cachingRepositoryEnumerator struct {
+	client client.RegistryClient
+	// a cache of opaque continue tokens for repository enumeration
+	cache *cache.LRUExpireCache
+}
+
+var _ RepositoryEnumerator = &cachingRepositoryEnumerator{}
+
+// NewCachingRepositoryEnumerator returns a new caching repository enumerator.
+func NewCachingRepositoryEnumerator(client client.RegistryClient, cache *cache.LRUExpireCache) RepositoryEnumerator {
+	return &cachingRepositoryEnumerator{
+		client: client,
+		cache:  cache,
+	}
+}
+
+type isHandlerFunc func(is *imageapiv1.ImageStream) error
+
+var errNoSpaceInSlice = errors.New("no space in slice")
+var errEnumerationFinished = errors.New("enumeration finished")
+
+func (re *cachingRepositoryEnumerator) EnumerateRepositories(
+	ctx context.Context,
+	repos []string,
+	last string,
+) (n int, err error) {
+	if len(repos) == 0 {
+		// Client explicitly requested 0 results. Returning nil for error seems more appropriate but this is
+		// more in line with upstream does. Returning nil actually makes the upstream code panic.
+		// TODO: patch upstream?  /_catalog?n=0  results in 500
+		return 0, errNoSpaceInSlice
+	}
+
+	err = re.enumerateImageStreams(ctx, int64(len(repos)), last, func(is *imageapiv1.ImageStream) error {
+		name := fmt.Sprintf("%s/%s", is.Namespace, is.Name)
+		repos[n] = name
+		n++
+
+		if n >= len(repos) {
+			return errEnumerationFinished
+		}
+
+		return nil
+	})
+
+	switch err {
+	case errEnumerationFinished:
+		err = nil
+	case nil:
+		err = io.EOF
+	}
+
+	return
+}
+
+func (r *cachingRepositoryEnumerator) enumerateImageStreams(
+	ctx context.Context,
+	limit int64,
+	last string,
+	handler isHandlerFunc,
+) error {
+	var (
+		start  string
+		warned bool
+	)
+
+	client, ok := userClientFrom(ctx)
+	if !ok {
+		context.GetLogger(ctx).Warnf("user token not set, falling back to registry client")
+		osClient, err := r.client.Client()
+		if err != nil {
+			return err
+		}
+		client = osClient
+	}
+
+	if len(last) > 0 {
+		if c, ok := r.cache.Get(last); !ok {
+			context.GetLogger(ctx).Warnf("failed to find opaque continue token for last repository=%q -> requesting the full image stream list instead of %d items", last, limit)
+			warned = true
+			limit = 0
+		} else {
+			start = c.(string)
+		}
+	}
+
+	iss, err := client.ImageStreams("").List(metav1.ListOptions{
+		Limit:    limit,
+		Continue: start,
+	})
+	if apierrors.IsResourceExpired(err) {
+		context.GetLogger(ctx).Warnf("continuation token expired (%v) -> requesting the full image stream list", err)
+		iss, err = client.ImageStreams("").List(metav1.ListOptions{})
+		warned = true
+	}
+
+	if err != nil {
+		return err
+	}
+
+	warnBrokenPagination := func(msg string) {
+		if !warned {
+			context.GetLogger(ctx).Warnf("pagination not working: %s; the master API does not support chunking", msg)
+			warned = true
+		}
+	}
+
+	if limit > 0 && limit < int64(len(iss.Items)) {
+		warnBrokenPagination(fmt.Sprintf("received %d image streams instead of requested maximum %d", len(iss.Items), limit))
+	}
+	if len(iss.Items) > 0 && len(iss.ListMeta.Continue) > 0 {
+		last := iss.Items[len(iss.Items)-1]
+		r.cache.Add(fmt.Sprintf("%s/%s", last.Namespace, last.Name), iss.ListMeta.Continue, paginationEntryTTL)
+	}
+
+	for _, is := range iss.Items {
+		name := fmt.Sprintf("%s/%s", is.Namespace, is.Name)
+		if len(last) > 0 && name <= last {
+			if !warned {
+				warnBrokenPagination(fmt.Sprintf("received unexpected repository name %q -"+
+					" lexicographically preceding the requested %q", name, last))
+			}
+			continue
+		}
+		err := handler(&is)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/dockerregistry/server/catalog_test.go
+++ b/pkg/dockerregistry/server/catalog_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/docker/distribution/context"
+
+	registryclient "github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+	"github.com/openshift/image-registry/pkg/testutil"
+)
+
+func TestCatalog(t *testing.T) {
+	const blobRepoCacheTTL = time.Millisecond * 500
+
+	type isMeta struct{ namespace, name string }
+
+	for _, tc := range []struct {
+		name          string
+		isObjectMeta  []isMeta
+		buffer        []string
+		last          string
+		expectedRepos []string
+		expectedError error
+	}{
+		{
+			name:          "no image streams",
+			buffer:        make([]string, 2),
+			expectedError: io.EOF,
+		},
+
+		{
+			name:          "one image stream",
+			isObjectMeta:  []isMeta{{"nm", "foo"}},
+			buffer:        make([]string, 2),
+			expectedRepos: []string{"nm/foo"},
+			expectedError: io.EOF,
+		},
+
+		{
+			name:          "2 image streams in the same namespace",
+			isObjectMeta:  []isMeta{{"nm", "foo"}, {"nm", "bar"}},
+			buffer:        make([]string, 2),
+			expectedRepos: []string{"nm/bar", "nm/foo"},
+			expectedError: nil,
+		},
+
+		{
+			name:          "3 image streams in different namespaces",
+			isObjectMeta:  []isMeta{{"fst", "is"}, {"snd", "is"}, {"trd", "name"}},
+			buffer:        make([]string, 4),
+			expectedRepos: []string{"fst/is", "snd/is", "trd/name"},
+			expectedError: io.EOF,
+		},
+
+		{
+			name: "repositories get sorted",
+			isObjectMeta: []isMeta{
+				{"nm", "ab"}, {"nmc", "aa"}, {"ab", "cd"}, {"ss", "is"}, {"ab", "aa"}, {"a", "nn"},
+			},
+			buffer:        make([]string, 7),
+			expectedRepos: []string{"a/nn", "ab/aa", "ab/cd", "nm/ab", "nmc/aa", "ss/is"},
+			expectedError: io.EOF,
+		},
+
+		{
+			name:          "short buffer",
+			isObjectMeta:  []isMeta{{"nm", "foo"}, {"nm", "bar"}},
+			buffer:        make([]string, 1),
+			expectedRepos: []string{"nm/bar"},
+			expectedError: nil,
+		},
+
+		{
+			name:          "skip the first",
+			isObjectMeta:  []isMeta{{"nm", "foo"}, {"nm", "bar"}},
+			buffer:        make([]string, 2),
+			last:          "nm/bar",
+			expectedRepos: []string{"nm/foo"},
+			expectedError: io.EOF,
+		},
+
+		{
+			name:          "skip the last",
+			isObjectMeta:  []isMeta{{"nm", "foo"}, {"nm", "bar"}},
+			buffer:        make([]string, 2),
+			last:          "nm/foo",
+			expectedRepos: []string{},
+			expectedError: io.EOF,
+		},
+
+		{
+			name:          "bigger buffer capacity does not matter",
+			isObjectMeta:  []isMeta{{"nm", "foo"}, {"nm", "bar"}},
+			buffer:        make([]string, 1, 2),
+			expectedRepos: []string{"nm/bar"},
+			expectedError: nil,
+		},
+
+		{
+			name:          "pick a repository in the middle",
+			isObjectMeta:  []isMeta{{"bar", "is"}, {"baz", "is"}, {"foo", "is"}},
+			buffer:        make([]string, 1),
+			last:          "bar/is",
+			expectedRepos: []string{"baz/is"},
+			expectedError: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = testutil.WithTestLogger(ctx, t)
+			ctx = withAuthPerformed(ctx)
+
+			fos, imageClient := testutil.NewFakeOpenShiftWithClient(ctx)
+			for _, is := range tc.isObjectMeta {
+				testutil.AddImageStream(t, fos, is.namespace, is.name, nil)
+			}
+
+			reg, err := newTestRegistry(
+				ctx,
+				registryclient.NewFakeRegistryAPIClient(nil, imageClient),
+				nil,
+				blobRepoCacheTTL,
+				false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			numFilled, err := reg.Repositories(ctx, tc.buffer, tc.last)
+			if a, e := err, tc.expectedError; a != e {
+				t.Errorf("got unexpected error: %q != %q", a, e)
+			}
+
+			if a, e := numFilled, len(tc.expectedRepos); a != e {
+				t.Errorf("got unexpected number of repos: %d != %d", numFilled, e)
+			}
+
+			for i := 0; i < numFilled || i < len(tc.expectedRepos); i++ {
+				if i < numFilled && i >= len(tc.expectedRepos) {
+					t.Errorf("got unexpected repository at position #%d: %q", i, tc.buffer[i])
+				} else if i < len(tc.expectedRepos) && i >= numFilled {
+					t.Errorf("expected repository %q not returned", tc.expectedRepos[i])
+				} else if a, e := tc.buffer[i], tc.expectedRepos[i]; a != e {
+					t.Errorf("got unexpected repository at position #%d: %q != %q", i, a, e)
+				}
+			}
+		})
+	}
+}

--- a/pkg/dockerregistry/server/registry.go
+++ b/pkg/dockerregistry/server/registry.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"errors"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/docker/distribution/reference"
+)
+
+// registry wraps upstream registry object and overrides some of its methods
+// TODO: collect metrics for reimplemented methods
+type registry struct {
+	registry   distribution.Namespace
+	enumerator RepositoryEnumerator
+}
+
+var _ distribution.Namespace = &registry{}
+
+func (r *registry) Scope() distribution.Scope {
+	return r.registry.Scope()
+}
+
+func (r *registry) Repository(ctx context.Context, name reference.Named) (distribution.Repository, error) {
+	return r.registry.Repository(ctx, name)
+}
+
+// Repositories lists repository names made out of image streams fetched from master API.
+func (r *registry) Repositories(ctx context.Context, repos []string, last string) (n int, err error) {
+	n, err = r.enumerator.EnumerateRepositories(ctx, repos, last)
+	if err == errNoSpaceInSlice {
+		return n, errors.New("client requested zero entries")
+	}
+	return
+}
+
+func (r *registry) Blobs() distribution.BlobEnumerator {
+	return r.registry.Blobs()
+}
+
+func (r *registry) BlobStatter() distribution.BlobStatter {
+	return r.registry.BlobStatter()
+}

--- a/pkg/dockerregistry/server/registry_test.go
+++ b/pkg/dockerregistry/server/registry_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"time"
 
+	kubecache "k8s.io/apimachinery/pkg/util/cache"
+
 	"github.com/docker/distribution"
 	dockercfg "github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
@@ -68,7 +70,8 @@ func newTestRegistry(
 		quotaEnforcing: &quotaEnforcingConfig{
 			enforcementEnabled: false,
 		},
-		metrics: metrics.NewNoopMetrics(),
+		metrics:         metrics.NewNoopMetrics(),
+		paginationCache: kubecache.NewLRUExpireCache(128),
 	}
 
 	if storageDriver == nil {


### PR DESCRIPTION
Implements the upstream repository catalog API call:

    GET /v2/_catalog

Returned is a list of repository names as json:

    200 OK
    Content-Type: application/json
    { "repositories": [ <name>, ... ] }

Pagination is supported by mapping the last returned repository name to an opaque continue token received from master API and using it on the next invocation.

Task: https://trello.com/c/AZINw5qI

Associated origin PR to allow registry to list image stream: openshift/origin#19879

Documentation: https://github.com/openshift/openshift-docs/pull/10102

**TODO:**
- [x] - tests
- [x] - use user token
- [x] - app holds just a lru cache