### PR TITLE
Support TEST_KUBECONFIG for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test-unit:
 
 test-integration:
 	# TODO(dmage): remove DOCKER_API_VERSION when our CI will upgrade Docker
-	DOCKER_API_VERSION=1.24 go test ./test/integration/...
+	GOTEST_FLAGS="$(TESTFLAGS)" DOCKER_API_VERSION=1.24 hack/test-go.sh test/integration/*
 .PHONY: test-integration
 
 # Remove all build artifacts.

--- a/test/integration/crossmount/crossmount_test.go
+++ b/test/integration/crossmount/crossmount_test.go
@@ -98,10 +98,7 @@ func TestCrossMount(t *testing.T) {
 	// Upload a random image to a new project.
 	uploadedImage := func(user *testframework.User, repoName string) sourceGenerator {
 		return func(t *testing.T, registry *testframework.Registry) (*projectapiv1.Project, reference.Named, distribution.Manifest, closeFn) {
-			project := testframework.CreateProject(t, adminKubeConfig, uniqueName(user.Name), user.Name)
-			close := func() {
-				testframework.DeleteProject(t, adminKubeConfig, project.Name)
-			}
+			project := master.CreateProject(uniqueName(user.Name), user.Name)
 
 			repo := registry.Repository(project.Name, repoName, user)
 			manifest, err := testutil.UploadSchema2Image(context.Background(), repo, "latest")
@@ -115,7 +112,7 @@ func TestCrossMount(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			return project, named, manifest, close
+			return project, named, manifest, noopClose
 		}
 	}
 

--- a/test/integration/offline/offline_test.go
+++ b/test/integration/offline/offline_test.go
@@ -160,7 +160,7 @@ func TestPullthroughBlob(t *testing.T) {
 	defer master.Close()
 
 	testuser := master.CreateUser("testuser", "testp@ssw0rd")
-	testproject := master.CreateProject("testproject", testuser.Name)
+	testproject := master.CreateProject("test-offline-image-pullthrough", testuser.Name)
 	teststreamName := "pullthrough"
 
 	t.Log("=== import image")

--- a/test/integration/pullthroughblob/pullthroughblob_test.go
+++ b/test/integration/pullthroughblob/pullthroughblob_test.go
@@ -30,7 +30,7 @@ func TestPullthroughBlob(t *testing.T) {
 	defer master.Close()
 
 	testuser := master.CreateUser("testuser", "testp@ssw0rd")
-	testproject := master.CreateProject("testproject", testuser.Name)
+	testproject := master.CreateProject("test-image-pullthrough-blob", testuser.Name)
 	teststreamName := "pullthrough"
 
 	requestCounter := counter.New()


### PR DESCRIPTION
Uses the provided administrator kubeconfig and runs the tests against
that master. This allows the integration tests to be run against a stock
"openshift start master".

Another change in the master will make local dev cases easier so allowed
registries doesn't have to be customized.

@bparees @legionus