### PR TITLE
Add metrics for the storage subsystem

### DIFF
--- a/pkg/dockerregistry/server/app.go
+++ b/pkg/dockerregistry/server/app.go
@@ -62,8 +62,8 @@ type App struct {
 }
 
 func (app *App) Storage(driver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
-	app.driver = driver
-	return driver, nil
+	app.driver = app.metrics.StorageDriver(driver)
+	return app.driver, nil
 }
 
 func (app *App) Registry(registry distribution.Namespace, options map[string]interface{}) (distribution.Namespace, error) {

--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"io"
 	"net/url"
 	"strings"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/wrapped"
 	"github.com/openshift/image-registry/pkg/origin-common/image/registryclient"
@@ -30,12 +32,15 @@ type Sink interface {
 	PullthroughBlobstoreCacheRequests(resultType string) Counter
 	PullthroughRepositoryDuration(registry, funcname string) Observer
 	PullthroughRepositoryErrors(registry, funcname, errcode string) Counter
+	StorageDuration(funcname string) Observer
+	StorageErrors(funcname, errcode string) Counter
 }
 
 // Metrics is a set of all metrics that can be provided.
 type Metrics interface {
 	Core
 	Pullthrough
+	Storage
 }
 
 // Core is a set of metrics for the core functionality.
@@ -52,6 +57,13 @@ type Pullthrough interface {
 	// DigestBlobStoreCache() returns an interface to count cache hits/misses
 	// for pullthrough blobstores.
 	DigestBlobStoreCache() Cache
+}
+
+// Storage is a set of metrics for the storage subsystem.
+type Storage interface {
+	// StorageDriver wraps distribution/registry/storage/driver.StorageDriver
+	// to collect statistics.
+	StorageDriver(driver storagedriver.StorageDriver) storagedriver.StorageDriver
 }
 
 func dockerErrorCode(err error) string {
@@ -89,6 +101,30 @@ func (rr repositoryRetriever) Repository(ctx gocontext.Context, registry *url.UR
 	}), nil
 }
 
+func storageSentinelError(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+	if _, ok := err.(storagedriver.ErrUnsupportedMethod); ok {
+		return true
+	}
+	return false
+}
+
+func storageErrorCode(err error) string {
+	switch err.(type) {
+	case storagedriver.ErrUnsupportedMethod:
+		return "UNSUPPORTED_METHOD"
+	case storagedriver.PathNotFoundError:
+		return "PATH_NOT_FOUND"
+	case storagedriver.InvalidPathError:
+		return "INVALID_PATH"
+	case storagedriver.InvalidOffsetError:
+		return "INVALID_OFFSET"
+	}
+	return "UNKNOWN"
+}
+
 type metrics struct {
 	sink Sink
 }
@@ -124,6 +160,17 @@ func (m *metrics) DigestBlobStoreCache() Cache {
 	}
 }
 
+func (m *metrics) StorageDriver(driver storagedriver.StorageDriver) storagedriver.StorageDriver {
+	return wrapped.NewStorageDriver(driver, func(funcname string, f func() error) error {
+		defer NewTimer(m.sink.StorageDuration(funcname)).Stop()
+		err := f()
+		if err != nil && !storageSentinelError(err) {
+			m.sink.StorageErrors(funcname, storageErrorCode(err)).Inc()
+		}
+		return err
+	})
+}
+
 type noopMetrics struct {
 }
 
@@ -145,4 +192,8 @@ func (m noopMetrics) RepositoryRetriever(retriever registryclient.RepositoryRetr
 
 func (m noopMetrics) DigestBlobStoreCache() Cache {
 	return noopCache{}
+}
+
+func (m noopMetrics) StorageDriver(driver storagedriver.StorageDriver) storagedriver.StorageDriver {
+	return driver
 }

--- a/pkg/dockerregistry/server/metrics/testing/counter.go
+++ b/pkg/dockerregistry/server/metrics/testing/counter.go
@@ -49,6 +49,18 @@ func (s counterSink) PullthroughRepositoryErrors(registry, funcname, errcode str
 	})
 }
 
+func (s counterSink) StorageDuration(funcname string) metrics.Observer {
+	return callbackObserver(func(float64) {
+		s.c.Add(fmt.Sprintf("storage:%s", funcname), 1)
+	})
+}
+
+func (s counterSink) StorageErrors(funcname, errcode string) metrics.Counter {
+	return callbackCounter(func() {
+		s.c.Add(fmt.Sprintf("storage_errors:%s:%s", funcname, errcode), 1)
+	})
+}
+
 func NewCounterSink() (counter.Counter, metrics.Sink) {
 	c := counter.New()
 	return c, counterSink{c: c}

--- a/pkg/dockerregistry/server/wrapped/filewriter.go
+++ b/pkg/dockerregistry/server/wrapped/filewriter.go
@@ -1,0 +1,50 @@
+package wrapped
+
+import (
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+// fileWriter wraps a distribution/registry/storage/driver.FileWriter.
+type fileWriter struct {
+	fileWriter storagedriver.FileWriter
+	wrapper    SimpleWrapper
+}
+
+var _ storagedriver.FileWriter = &fileWriter{}
+
+func NewFileWriter(w storagedriver.FileWriter, wrapper SimpleWrapper) storagedriver.FileWriter {
+	return &fileWriter{
+		fileWriter: w,
+		wrapper:    wrapper,
+	}
+}
+
+func (w *fileWriter) Size() int64 {
+	return w.fileWriter.Size()
+}
+
+func (w *fileWriter) Write(p []byte) (n int, err error) {
+	err = w.wrapper("FileWriter.Write", func() error {
+		n, err = w.fileWriter.Write(p)
+		return err
+	})
+	return
+}
+
+func (w *fileWriter) Close() error {
+	return w.wrapper("FileWriter.Close", func() error {
+		return w.fileWriter.Close()
+	})
+}
+
+func (w *fileWriter) Cancel() error {
+	return w.wrapper("FileWriter.Cancel", func() error {
+		return w.fileWriter.Cancel()
+	})
+}
+
+func (w *fileWriter) Commit() error {
+	return w.wrapper("FileWriter.Commit", func() error {
+		return w.fileWriter.Commit()
+	})
+}

--- a/pkg/dockerregistry/server/wrapped/readcloser.go
+++ b/pkg/dockerregistry/server/wrapped/readcloser.go
@@ -1,0 +1,32 @@
+package wrapped
+
+import "io"
+
+// readCloser wraps io.ReadCloser.
+type readCloser struct {
+	readCloser io.ReadCloser
+	wrapper    SimpleWrapper
+}
+
+var _ io.ReadCloser = &readCloser{}
+
+func NewReadCloser(r io.ReadCloser, wrapper SimpleWrapper) io.ReadCloser {
+	return &readCloser{
+		readCloser: r,
+		wrapper:    wrapper,
+	}
+}
+
+func (r *readCloser) Read(p []byte) (n int, err error) {
+	err = r.wrapper("ReadCloser.Read", func() error {
+		n, err = r.readCloser.Read(p)
+		return err
+	})
+	return
+}
+
+func (r *readCloser) Close() error {
+	return r.wrapper("ReadCloser.Close", func() error {
+		return r.readCloser.Close()
+	})
+}

--- a/pkg/dockerregistry/server/wrapped/storagedriver.go
+++ b/pkg/dockerregistry/server/wrapped/storagedriver.go
@@ -1,0 +1,105 @@
+package wrapped
+
+import (
+	"io"
+
+	"github.com/docker/distribution/context"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+// storageDriver wraps a distribution/registry/storage/driver.StorageDriver.
+type storageDriver struct {
+	storageDriver storagedriver.StorageDriver
+	wrapper       SimpleWrapper
+}
+
+var _ storagedriver.StorageDriver = &storageDriver{}
+
+func NewStorageDriver(driver storagedriver.StorageDriver, wrapper SimpleWrapper) storagedriver.StorageDriver {
+	return &storageDriver{
+		storageDriver: driver,
+		wrapper:       wrapper,
+	}
+}
+
+func (d *storageDriver) Name() string {
+	return d.storageDriver.Name()
+}
+
+func (d *storageDriver) GetContent(ctx context.Context, path string) (content []byte, err error) {
+	err = d.wrapper("StorageDriver.GetContent", func() error {
+		content, err = d.storageDriver.GetContent(ctx, path)
+		return err
+	})
+	return
+}
+
+func (d *storageDriver) PutContent(ctx context.Context, path string, content []byte) error {
+	return d.wrapper("StorageDriver.PutContent", func() error {
+		return d.storageDriver.PutContent(ctx, path, content)
+	})
+}
+
+func (d *storageDriver) Reader(ctx context.Context, path string, offset int64) (r io.ReadCloser, err error) {
+	err = d.wrapper("StorageDriver.Reader", func() error {
+		r, err = d.storageDriver.Reader(ctx, path, offset)
+		if err == nil {
+			r = &readCloser{
+				readCloser: r,
+				wrapper:    d.wrapper,
+			}
+		}
+		return err
+	})
+	return
+}
+
+func (d *storageDriver) Writer(ctx context.Context, path string, append bool) (w storagedriver.FileWriter, err error) {
+	err = d.wrapper("StorageDriver.Writer", func() error {
+		w, err = d.storageDriver.Writer(ctx, path, append)
+		if err == nil {
+			w = &fileWriter{
+				fileWriter: w,
+				wrapper:    d.wrapper,
+			}
+		}
+		return err
+	})
+	return
+}
+
+func (d *storageDriver) Stat(ctx context.Context, path string) (fi storagedriver.FileInfo, err error) {
+	err = d.wrapper("StorageDriver.Stat", func() error {
+		fi, err = d.storageDriver.Stat(ctx, path)
+		return err
+	})
+	return
+}
+
+func (d *storageDriver) List(ctx context.Context, path string) (entries []string, err error) {
+	err = d.wrapper("StorageDriver.List", func() error {
+		entries, err = d.storageDriver.List(ctx, path)
+		return err
+	})
+	return
+}
+
+func (d *storageDriver) Move(ctx context.Context, sourcePath string, destPath string) error {
+	return d.wrapper("StorageDriver.Move", func() error {
+		return d.storageDriver.Move(ctx, sourcePath, destPath)
+	})
+}
+
+func (d *storageDriver) Delete(ctx context.Context, path string) error {
+	return d.wrapper("StorageDriver.Delete", func() error {
+		return d.storageDriver.Delete(ctx, path)
+	})
+}
+
+func (d *storageDriver) URLFor(ctx context.Context, path string, options map[string]interface{}) (url string, err error) {
+	err = d.wrapper("StorageDriver.URLFor", func() error {
+		url, err = d.storageDriver.URLFor(ctx, path, options)
+		return err
+	})
+	return
+}

--- a/pkg/dockerregistry/server/wrapped/wrapper.go
+++ b/pkg/dockerregistry/server/wrapped/wrapper.go
@@ -2,6 +2,12 @@ package wrapped
 
 import "github.com/docker/distribution/context"
 
-// Wrapper is a user defined function that wraps a method and can control the
-// execution flow, modify its context and handle errors.
+// Wrapper is a user defined function that wraps methods to control their
+// execution flow, contexts and error reporing.
 type Wrapper func(ctx context.Context, funcname string, f func(ctx context.Context) error) error
+
+// SimpleWrapper is a user defined function that wraps methods to control the
+// execution flow and error reporing of methods. Unlike Wrapper, it wraps
+// functions that don't use contexts, including low-level functions like
+// (io.Reader).Read.
+type SimpleWrapper func(funcname string, f func() error) error

--- a/test/integration/metricspullthrough/metricspullthrough_test.go
+++ b/test/integration/metricspullthrough/metricspullthrough_test.go
@@ -150,6 +150,14 @@ func TestPullthroughBlob(t *testing.T) {
 		values []string
 	}{
 		{
+			name:   "imageregistry_storage_duration_seconds_bucket",
+			values: []string{`operation="StorageDriver.Stat"`},
+		},
+		{
+			name:   "imageregistry_storage_errors_total",
+			values: []string{`operation="StorageDriver.Stat"`, `code="PATH_NOT_FOUND"`},
+		},
+		{
 			name:   "imageregistry_pullthrough_repository_errors_total",
 			values: []string{`operation="BlobStore.Stat"`, `code="UNAUTHORIZED"`},
 		},


### PR DESCRIPTION
https://trello.com/c/g3380oUO/1534-8-implement-recommended-registry-metrics-registry

New metrics:

  * imageregistry_storage_duration_seconds_bucket{operation,le}
  * imageregistry_storage_duration_seconds_sum{operation}
  * imageregistry_storage_duration_seconds_count{operation}
  * imageregistry_storage_errors_total{operation,code}