### PR TITLE
[3.9] UPSTREAM: docker/distribution: 2605: s3: Add eu-west-3 region

### DIFF
--- a/vendor/github.com/docker/distribution/registry/storage/driver/s3-aws/s3.go
+++ b/vendor/github.com/docker/distribution/registry/storage/driver/s3-aws/s3.go
@@ -108,6 +108,7 @@ func init() {
 		"us-west-2",
 		"eu-west-1",
 		"eu-west-2",
+		"eu-west-3",
 		"eu-central-1",
 		"ap-south-1",
 		"ap-southeast-1",


### PR DESCRIPTION
Backport: https://github.com/openshift/image-registry/pull/94
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1587996
