### PR TITLE
Logs

### DIFF
--- a/images/dockerregistry/config.yml
+++ b/images/dockerregistry/config.yml
@@ -1,6 +1,6 @@
 version: 0.1
 log:
-  level: debug
+  level: info
 http:
   addr: :5000
 storage:

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -14,7 +14,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	logrus_logstash "github.com/bshuster-repo/logrus-logstash-hook"
-	gorillahandlers "github.com/gorilla/handlers"
 
 	"github.com/docker/distribution/configuration"
 	"github.com/docker/distribution/context"
@@ -192,7 +191,7 @@ func NewServer(ctx context.Context, dockerConfig *configuration.Configuration, e
 	handler = health.Handler(handler)
 	handler = panicHandler(handler)
 	if !dockerConfig.Log.AccessLog.Disabled {
-		handler = gorillahandlers.CombinedLoggingHandler(os.Stdout, handler)
+		handler = logrusLoggingHandler(ctx, handler)
 	}
 
 	var tlsConf *tls.Config
@@ -382,4 +381,29 @@ func setDefaultLogParameters(config *configuration.Configuration) {
 		config.Log.Fields = make(map[string]interface{})
 	}
 	config.Log.Fields[audit.LogEntryType] = audit.DefaultLoggerType
+}
+
+func logrusLoggingHandler(ctx context.Context, h http.Handler) http.Handler {
+	return loggingHandler{
+		ctx:     ctx,
+		handler: h,
+	}
+}
+
+type loggingHandler struct {
+	ctx     context.Context
+	handler http.Handler
+}
+
+func (h loggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := h.ctx
+
+	ctx = context.WithRequest(ctx, r)
+	ctx, w = context.WithResponseWriter(ctx, w)
+	logger := context.GetRequestLogger(ctx)
+	ctx = context.WithLogger(ctx, logger)
+
+	h.handler.ServeHTTP(w, r)
+
+	context.GetResponseLogger(ctx).Infof("response")
 }

--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -191,7 +191,9 @@ func NewServer(ctx context.Context, dockerConfig *configuration.Configuration, e
 	handler = alive("/healthz", handler)
 	handler = health.Handler(handler)
 	handler = panicHandler(handler)
-	handler = gorillahandlers.CombinedLoggingHandler(os.Stdout, handler)
+	if !dockerConfig.Log.AccessLog.Disabled {
+		handler = gorillahandlers.CombinedLoggingHandler(os.Stdout, handler)
+	}
 
 	var tlsConf *tls.Config
 	if dockerConfig.HTTP.TLS.Certificate != "" {

--- a/pkg/dockerregistry/server/app.go
+++ b/pkg/dockerregistry/server/app.go
@@ -186,5 +186,7 @@ func NewApp(ctx context.Context, registryClient client.RegistryClient, dockerCon
 		h = promhttp.InstrumentHandlerTimeToWriteHeader(metrics.HTTPTimeToWriteHeaderSeconds, h)
 	}
 
+	context.GetLogger(dockerApp).Infof("Using %q as Docker Registry URL", extraConfig.Server.Addr)
+
 	return h
 }

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -42,6 +42,13 @@ func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool,
 
 	image, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
 	if err != nil {
+		switch err.Code {
+		case imagestream.ErrImageStreamImageNotFoundCode:
+			context.GetLogger(ctx).Errorf("manifestService.Exists: image %s is not found in imagestream %s", dgst.String(), m.imageStream.Reference())
+			fallthrough
+		case imagestream.ErrImageStreamNotFoundCode:
+			return false, distribution.ErrBlobUnknown
+		}
 		return false, err
 	}
 	return image != nil, nil
@@ -51,9 +58,20 @@ func (m *manifestService) Exists(ctx context.Context, dgst digest.Digest) (bool,
 func (m *manifestService) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
 	context.GetLogger(ctx).Debugf("(*manifestService).Get")
 
-	image, err := m.imageStream.GetImageOfImageStream(ctx, dgst)
-	if err != nil {
-		return nil, err
+	image, rErr := m.imageStream.GetImageOfImageStream(ctx, dgst)
+	if rErr != nil {
+		switch rErr.Code {
+		case imagestream.ErrImageStreamNotFoundCode, imagestream.ErrImageStreamImageNotFoundCode:
+			context.GetLogger(ctx).Errorf("manifestService.Get: unable to get image %s in imagestream %s: %v", dgst.String(), m.imageStream.Reference(), rErr)
+			return nil, distribution.ErrManifestUnknownRevision{
+				Name:     m.imageStream.Reference(),
+				Revision: dgst,
+			}
+		case imagestream.ErrImageStreamForbiddenCode:
+			context.GetLogger(ctx).Errorf("manifestService.Get: unable to get access to imagestream %s to find image %s: %v", m.imageStream.Reference(), dgst.String(), rErr)
+			return nil, distribution.ErrAccessDenied
+		}
+		return nil, rErr
 	}
 
 	// Reference without a registry part refers to repository containing locally managed images.
@@ -166,8 +184,20 @@ func (m *manifestService) Put(ctx context.Context, manifest distribution.Manifes
 		}
 	}
 
-	if err = m.imageStream.CreateImageStreamMapping(ctx, uclient, tag, image); err != nil {
-		return "", err
+	rErr := m.imageStream.CreateImageStreamMapping(ctx, uclient, tag, image)
+	if rErr != nil {
+		switch rErr.Code {
+		case imagestream.ErrImageStreamNotFoundCode:
+			context.GetLogger(ctx).Errorf("manifestService.Put: imagestreammapping failed for image %s@%s: %v", m.imageStream.Reference(), image.Name, rErr)
+			return "", distribution.ErrManifestUnknownRevision{
+				Name:     m.imageStream.Reference(),
+				Revision: dgst,
+			}
+		case imagestream.ErrImageStreamForbiddenCode:
+			context.GetLogger(ctx).Errorf("manifestService.Put: imagestreammapping got access denied for image %s@%s: %v", m.imageStream.Reference(), image.Name, rErr)
+			return "", distribution.ErrAccessDenied
+		}
+		return "", rErr
 	}
 
 	return dgst, nil
@@ -187,7 +217,14 @@ func (m *manifestService) Delete(ctx context.Context, dgst digest.Digest) error 
 		// change the availability of the manifest, so we reject this request.
 		return distribution.ErrUnsupported
 	}
-	if _, ok := err.(distribution.ErrManifestUnknownRevision); !ok {
+
+	switch err.Code {
+	case imagestream.ErrImageStreamNotFoundCode, imagestream.ErrImageStreamImageNotFoundCode:
+		// There is no image/imagestream. Let's just delete the link.
+	case imagestream.ErrImageStreamForbiddenCode:
+		context.GetLogger(ctx).Errorf("manifestService.Delete: unable to get access to imagestream %s to find image %s: %v", m.imageStream.Reference(), dgst.String(), err)
+		return distribution.ErrAccessDenied
+	default:
 		return err
 	}
 

--- a/pkg/dockerregistry/server/manifestservice.go
+++ b/pkg/dockerregistry/server/manifestservice.go
@@ -231,6 +231,6 @@ func (m *manifestService) storeManifestLocally(ctx context.Context, image *image
 	}
 
 	if err := m.imageStream.ImageManifestBlobStored(ctx, image); err != nil {
-		context.GetLogger(ctx).Errorf("error updating Image: %v", err)
+		context.GetLogger(ctx).Errorf("unable to update image: %v", err)
 	}
 }

--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -39,7 +39,7 @@ func (pbs *pullthroughBlobStore) Stat(ctx context.Context, dgst digest.Digest) (
 		// continue on to the code below and look up the blob in a remote store since it is not in
 		// the local store
 	case err != nil:
-		context.GetLogger(ctx).Errorf("Failed to find blob %q: %#v", dgst.String(), err)
+		context.GetLogger(ctx).Errorf("unable to find blob %q: %#v", dgst.String(), err)
 		fallthrough
 	default:
 		return desc, err
@@ -62,7 +62,7 @@ func (pbs *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseW
 		// continue on to the code below and look up the blob in a remote store since it is not in
 		// the local store
 	case err != nil:
-		context.GetLogger(ctx).Errorf("Failed to find blob %q: %#v", dgst.String(), err)
+		context.GetLogger(ctx).Errorf("unable to serve blob %q: %#v", dgst.String(), err)
 		fallthrough
 	default:
 		return err

--- a/pkg/dockerregistry/server/pullthroughmanifestservice.go
+++ b/pkg/dockerregistry/server/pullthroughmanifestservice.go
@@ -112,7 +112,7 @@ func (m *pullthroughManifestService) getRemoteRepositoryClient(ctx context.Conte
 		}
 	}
 
-	insecure, err := m.imageStream.TagIsInsecure(tag, dgst)
+	insecure, err := m.imageStream.TagIsInsecure(ctx, tag, dgst)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerregistry/server/remoteblobgetter.go
+++ b/pkg/dockerregistry/server/remoteblobgetter.go
@@ -89,7 +89,7 @@ func NewBlobGetterService(
 func (rbgs *remoteBlobGetterService) findBlobStore(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, distribution.BlobStore, error) {
 	// look up the potential remote repositories that this blob could be part of (at this time,
 	// we don't know which image in the image stream surfaced the content).
-	ok, err := rbgs.imageStream.Exists()
+	ok, err := rbgs.imageStream.Exists(ctx)
 	if err != nil {
 		return distribution.Descriptor{}, nil, err
 	}
@@ -102,7 +102,7 @@ func (rbgs *remoteBlobGetterService) findBlobStore(ctx context.Context, dgst dig
 	retriever := getImportContext(ctx, rbgs.getSecrets, rbgs.metrics)
 
 	// look at the first level of tagged repositories first
-	repositoryCandidates, search, err := rbgs.imageStream.IdentifyCandidateRepositories(true)
+	repositoryCandidates, search, err := rbgs.imageStream.IdentifyCandidateRepositories(ctx, true)
 	if err != nil {
 		return distribution.Descriptor{}, nil, err
 	}
@@ -111,7 +111,7 @@ func (rbgs *remoteBlobGetterService) findBlobStore(ctx context.Context, dgst dig
 	}
 
 	// look at all other repositories tagged by the server
-	repositoryCandidates, secondary, err := rbgs.imageStream.IdentifyCandidateRepositories(false)
+	repositoryCandidates, secondary, err := rbgs.imageStream.IdentifyCandidateRepositories(ctx, false)
 	if err != nil {
 		return distribution.Descriptor{}, nil, err
 	}

--- a/pkg/dockerregistry/server/repository.go
+++ b/pkg/dockerregistry/server/repository.go
@@ -56,8 +56,6 @@ func (app *App) Repository(ctx context.Context, repo distribution.Repository, cr
 		return nil, nil, err
 	}
 
-	context.GetLogger(ctx).Infof("Using %q as Docker Registry URL", app.config.Server.Addr)
-
 	namespace, name, err := getNamespaceName(repo.Named().Name())
 	if err != nil {
 		return nil, nil, err
@@ -191,10 +189,6 @@ func (r *repository) BlobDescriptorService(svc distribution.BlobDescriptorServic
 }
 
 func (r *repository) checkPendingErrors(ctx context.Context) error {
-	return checkPendingErrors(ctx, context.GetLogger(r.ctx), r.imageStream.Reference())
-}
-
-func checkPendingErrors(ctx context.Context, logger context.Logger, ref string) error {
 	if !authPerformed(ctx) {
 		return fmt.Errorf("openshift.auth.completed missing from context")
 	}
@@ -204,11 +198,12 @@ func checkPendingErrors(ctx context.Context, logger context.Logger, ref string) 
 		return nil
 	}
 
-	repoErr, haveRepoErr := deferredErrors.Get(ref)
+	repoErr, haveRepoErr := deferredErrors.Get(r.imageStream.Reference())
 	if !haveRepoErr {
 		return nil
 	}
 
-	logger.Debugf("Origin auth: found deferred error for %s: %v", ref, repoErr)
+	context.GetLogger(r.ctx).Debugf("Origin auth: found deferred error for %s: %v", r.imageStream.Reference(), repoErr)
+
 	return repoErr
 }

--- a/pkg/dockerregistry/server/tagservice.go
+++ b/pkg/dockerregistry/server/tagservice.go
@@ -15,7 +15,7 @@ type tagService struct {
 }
 
 func (t tagService) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
-	ok, err := t.imageStream.Exists()
+	ok, err := t.imageStream.Exists(ctx)
 	if err != nil {
 		return distribution.Descriptor{}, err
 	}
@@ -38,7 +38,7 @@ func (t tagService) Get(ctx context.Context, tag string) (distribution.Descripto
 }
 
 func (t tagService) All(ctx context.Context) ([]string, error) {
-	ok, err := t.imageStream.Exists()
+	ok, err := t.imageStream.Exists(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (t tagService) All(ctx context.Context) ([]string, error) {
 }
 
 func (t tagService) Lookup(ctx context.Context, desc distribution.Descriptor) ([]string, error) {
-	ok, err := t.imageStream.Exists()
+	ok, err := t.imageStream.Exists(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dockerregistry/server/token.go
+++ b/pkg/dockerregistry/server/token.go
@@ -39,7 +39,7 @@ func (t *tokenHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			case "repository", "signature":
 				_, _, err := getNamespaceName(access.Resource.Name)
 				if err != nil {
-					context.GetRequestLogger(ctx).Debugf("auth token request for unsupported resource name: %s", access.Resource.Name)
+					context.GetRequestLogger(ctx).Errorf("auth token request for unsupported resource name: %s", access.Resource.Name)
 					t.writeError(w, req, err.Error())
 					return
 				}
@@ -71,7 +71,7 @@ func (t *tokenHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if _, err := osClient.Users().Get("~", metav1.GetOptions{}); err != nil {
-		context.GetRequestLogger(ctx).Debugf("invalid token: %v", err)
+		context.GetRequestLogger(ctx).Errorf("invalid token: %v", err)
 		t.writeUnauthorized(w, req)
 		return
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"fmt"
 	"net/http"
 
 	errcode "github.com/docker/distribution/registry/api/errcode"
@@ -17,3 +18,24 @@ var (
 		HTTPStatusCode: http.StatusNotFound,
 	})
 )
+
+// Error provides a wrapper around error.
+type Error struct {
+	Code    string
+	Message string
+	Err     error
+}
+
+var _ error = Error{}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.Code, e.Message, e.Err.Error())
+}
+
+func NewError(code, msg string, err error) *Error {
+	return &Error{
+		Code:    code,
+		Message: msg,
+		Err:     err,
+	}
+}

--- a/pkg/imagestream/cachedimagestreamgetter.go
+++ b/pkg/imagestream/cachedimagestreamgetter.go
@@ -1,7 +1,6 @@
 package imagestream
 
 import (
-	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/registry/api/errcode"
 	disterrors "github.com/docker/distribution/registry/api/v2"
 
@@ -16,7 +15,6 @@ import (
 
 // cachedImageStreamGetter wraps a master API client for getting image streams with a cache.
 type cachedImageStreamGetter struct {
-	ctx               context.Context
 	namespace         string
 	name              string
 	isNamespacer      client.ImageStreamsNamespacer
@@ -25,12 +23,10 @@ type cachedImageStreamGetter struct {
 
 func (g *cachedImageStreamGetter) get() (*imageapiv1.ImageStream, error) {
 	if g.cachedImageStream != nil {
-		context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).getImageStream: returning cached copy")
 		return g.cachedImageStream, nil
 	}
 	is, err := g.isNamespacer.ImageStreams(g.namespace).Get(g.name, metav1.GetOptions{})
 	if err != nil {
-		context.GetLogger(g.ctx).Errorf("failed to get image stream: %v", err)
 		switch {
 		case kerrors.IsNotFound(err):
 			return nil, disterrors.ErrorCodeNameUnknown.WithDetail(err)
@@ -41,12 +37,10 @@ func (g *cachedImageStreamGetter) get() (*imageapiv1.ImageStream, error) {
 		}
 	}
 
-	context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).getImageStream: got image stream %s/%s", is.Namespace, is.Name)
 	g.cachedImageStream = is
 	return is, nil
 }
 
 func (g *cachedImageStreamGetter) cacheImageStream(is *imageapiv1.ImageStream) {
-	context.GetLogger(g.ctx).Debugf("(*cachedImageStreamGetter).cacheImageStream: got image stream %s/%s", is.Namespace, is.Name)
 	g.cachedImageStream = is
 }

--- a/pkg/imagestream/imagestream.go
+++ b/pkg/imagestream/imagestream.go
@@ -5,11 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/distribution"
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
-	"github.com/docker/distribution/registry/api/errcode"
-	disterrors "github.com/docker/distribution/registry/api/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,9 +16,18 @@ import (
 	imageapiv1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
+	rerrors "github.com/openshift/image-registry/pkg/errors"
 	imageapi "github.com/openshift/image-registry/pkg/origin-common/image/apis/image"
 	quotautil "github.com/openshift/image-registry/pkg/origin-common/quota/util"
 	originutil "github.com/openshift/image-registry/pkg/origin-common/util"
+)
+
+const (
+	ErrImageStreamCode              = "ImageStream:"
+	ErrImageStreamUnknownErrorCode  = ErrImageStreamCode + "Unknown"
+	ErrImageStreamNotFoundCode      = ErrImageStreamCode + "NotFound"
+	ErrImageStreamImageNotFoundCode = ErrImageStreamCode + "ImageNotFound"
+	ErrImageStreamForbiddenCode     = ErrImageStreamCode + "Forbidden"
 )
 
 // ProjectObjectListStore represents a cache of objects indexed by a project name.
@@ -40,20 +46,20 @@ type ImagePullthroughSpec struct {
 
 type ImageStream interface {
 	Reference() string
-	Exists(ctx context.Context) (bool, error)
+	Exists(ctx context.Context) (bool, *rerrors.Error)
 
-	GetImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, error)
-	CreateImageStreamMapping(ctx context.Context, userClient client.Interface, tag string, image *imageapiv1.Image) error
-	ImageManifestBlobStored(ctx context.Context, image *imageapiv1.Image) error
-	ResolveImageID(ctx context.Context, dgst digest.Digest) (*imageapiv1.TagEvent, error)
+	GetImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, *rerrors.Error)
+	CreateImageStreamMapping(ctx context.Context, userClient client.Interface, tag string, image *imageapiv1.Image) *rerrors.Error
+	ImageManifestBlobStored(ctx context.Context, image *imageapiv1.Image) *rerrors.Error
+	ResolveImageID(ctx context.Context, dgst digest.Digest) (*imageapiv1.TagEvent, *rerrors.Error)
 
 	HasBlob(ctx context.Context, dgst digest.Digest) *imageapiv1.Image
-	IdentifyCandidateRepositories(ctx context.Context, primary bool) ([]string, map[string]ImagePullthroughSpec, error)
-	GetLimitRangeList(ctx context.Context, cache ProjectObjectListStore) (*corev1.LimitRangeList, error)
-	GetSecrets() ([]corev1.Secret, error)
+	IdentifyCandidateRepositories(ctx context.Context, primary bool) ([]string, map[string]ImagePullthroughSpec, *rerrors.Error)
+	GetLimitRangeList(ctx context.Context, cache ProjectObjectListStore) (*corev1.LimitRangeList, *rerrors.Error)
+	GetSecrets() ([]corev1.Secret, *rerrors.Error)
 
-	TagIsInsecure(ctx context.Context, tag string, dgst digest.Digest) (bool, error)
-	Tags(ctx context.Context) (map[string]digest.Digest, error)
+	TagIsInsecure(ctx context.Context, tag string, dgst digest.Digest) (bool, *rerrors.Error)
+	Tags(ctx context.Context) (map[string]digest.Digest, *rerrors.Error)
 }
 
 type imageStream struct {
@@ -88,55 +94,50 @@ func (is *imageStream) Reference() string {
 	return fmt.Sprintf("%s/%s", is.namespace, is.name)
 }
 
-// createImageStream creates a new image stream and caches it.
-func (is *imageStream) createImageStream(ctx context.Context, userClient client.Interface) (*imageapiv1.ImageStream, error) {
-	stream := &imageapiv1.ImageStream{}
-	stream.Name = is.name
-
-	stream, err := userClient.ImageStreams(is.namespace).Create(stream)
-	switch {
-	case kerrors.IsAlreadyExists(err), kerrors.IsConflict(err):
-		context.GetLogger(ctx).Infof("conflict while creating ImageStream: %v", err)
-		is, err := is.imageStreamGetter.get()
-		if err != nil {
-			context.GetLogger(ctx).Errorf("createImageStream: failed to get image stream: %v", err)
-		}
-		return is, err
-	case kerrors.IsForbidden(err), kerrors.IsUnauthorized(err), quotautil.IsErrorQuotaExceeded(err):
-		context.GetLogger(ctx).Errorf("denied creating ImageStream: %v", err)
-		return nil, errcode.ErrorCodeDenied.WithDetail(err)
-	case err != nil:
-		context.GetLogger(ctx).Errorf("error auto provisioning ImageStream: %s", err)
-		return nil, errcode.ErrorCodeUnknown.WithDetail(err)
-	}
-
-	context.GetLogger(ctx).Debugf("cache image stream %s/%s", stream.Namespace, stream.Name)
-	is.imageStreamGetter.cacheImageStream(stream)
-
-	return stream, nil
-}
-
 // getImage retrieves the Image with digest `dgst`. No authorization check is done.
-func (is *imageStream) getImage(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, error) {
+func (is *imageStream) getImage(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, *rerrors.Error) {
 	image, err := is.imageClient.Get(ctx, dgst)
-	if err != nil {
-		return nil, wrapKStatusErrorOnGetImage(is.name, dgst, err)
+
+	switch {
+	case kerrors.IsNotFound(err):
+		return nil, rerrors.NewError(
+			ErrImageStreamImageNotFoundCode,
+			fmt.Sprintf("getImage: unable to find image digest %s in %s", dgst.String(), is.name),
+			err,
+		)
+	case err != nil:
+		return nil, rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("getImage: unable to get image digest %s in %s", dgst.String(), is.name),
+			err,
+		)
 	}
+
 	return image, nil
 }
 
 // ResolveImageID returns latest TagEvent for specified imageID and an error if
 // there's more than one image matching the ID or when one does not exist.
-func (is *imageStream) ResolveImageID(ctx context.Context, dgst digest.Digest) (*imageapiv1.TagEvent, error) {
-	stream, err := is.imageStreamGetter.get()
-	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.ResolveImageID: failed to get image stream: %v", err)
-		return nil, err
+func (is *imageStream) ResolveImageID(ctx context.Context, dgst digest.Digest) (*imageapiv1.TagEvent, *rerrors.Error) {
+	stream, rErr := is.imageStreamGetter.get()
+
+	if rErr != nil {
+		return nil, convertImageStreamGetterError(rErr, fmt.Sprintf("ResolveImageID: failed to get image stream %s", is.Reference()))
 	}
 
 	tagEvent, err := originutil.ResolveImageID(stream, dgst.String())
 	if err != nil {
-		return nil, err
+		code := ErrImageStreamUnknownErrorCode
+
+		if kerrors.IsNotFound(err) {
+			code = ErrImageStreamImageNotFoundCode
+		}
+
+		return nil, rerrors.NewError(
+			code,
+			fmt.Sprintf("ResolveImageID: unable to resolve ImageID %s in image stream %s", dgst.String(), is.Reference()),
+			err,
+		)
 	}
 
 	return tagEvent, nil
@@ -153,16 +154,15 @@ func (is *imageStream) ResolveImageID(ctx context.Context, dgst digest.Digest) (
 //
 // If you need the image object to be modified according to image stream tag,
 // please use GetImageOfImageStream.
-func (is *imageStream) getStoredImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, *imageapiv1.TagEvent, error) {
+func (is *imageStream) getStoredImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, *imageapiv1.TagEvent, *rerrors.Error) {
 	tagEvent, err := is.ResolveImageID(ctx, dgst)
 	if err != nil {
-		context.GetLogger(ctx).Errorf("failed to resolve image %s in ImageStream %s: %v", dgst.String(), is.Reference(), err)
-		return nil, nil, wrapKStatusErrorOnGetImage(is.name, dgst, err)
+		return nil, nil, err
 	}
 
 	image, err := is.getImage(ctx, dgst)
 	if err != nil {
-		return nil, nil, wrapKStatusErrorOnGetImage(is.name, dgst, err)
+		return nil, nil, err
 	}
 
 	return image, tagEvent, nil
@@ -176,7 +176,7 @@ func (is *imageStream) getStoredImageOfImageStream(ctx context.Context, dgst dig
 // NOTE: due to on the fly modification, the returned image object should
 // not be sent to the master API. If you need unmodified version of the
 // image object, please use getStoredImageOfImageStream.
-func (is *imageStream) GetImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, error) {
+func (is *imageStream) GetImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, *rerrors.Error) {
 	image, tagEvent, err := is.getStoredImageOfImageStream(ctx, dgst)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (is *imageStream) GetImageOfImageStream(ctx context.Context, dgst digest.Di
 }
 
 // ImageManifestBlobStored adds the imageapi.ImageManifestBlobStoredAnnotation annotation to image.
-func (is *imageStream) ImageManifestBlobStored(ctx context.Context, image *imageapiv1.Image) error {
+func (is *imageStream) ImageManifestBlobStored(ctx context.Context, image *imageapiv1.Image) *rerrors.Error {
 	image, err := is.getImage(ctx, digest.Digest(image.Name)) // ensure that we have the image object from master API
 	if err != nil {
 		return err
@@ -206,26 +206,34 @@ func (is *imageStream) ImageManifestBlobStored(ctx context.Context, image *image
 	image.Annotations[imageapi.ImageManifestBlobStoredAnnotation] = "true"
 
 	if _, err := is.registryOSClient.Images().Update(image); err != nil {
-		return fmt.Errorf("error updating Image: %v", err)
+		return rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("ImageManifestBlobStored: error updating image %s", image.Name),
+			err,
+		)
 	}
 	return nil
 }
 
-func (is *imageStream) GetSecrets() ([]corev1.Secret, error) {
+func (is *imageStream) GetSecrets() ([]corev1.Secret, *rerrors.Error) {
 	secrets, err := is.registryOSClient.ImageStreamSecrets(is.namespace).Secrets(is.name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting secrets for repository %s: %v", is.Reference(), err)
+		return nil, rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("GetSecrets: error getting secrets for repository %s", is.Reference()),
+			err,
+		)
 	}
 	return secrets.Items, nil
 }
 
 // TagIsInsecure returns true if the given image stream or its tag allow for
 // insecure transport.
-func (is *imageStream) TagIsInsecure(ctx context.Context, tag string, dgst digest.Digest) (bool, error) {
+func (is *imageStream) TagIsInsecure(ctx context.Context, tag string, dgst digest.Digest) (bool, *rerrors.Error) {
 	stream, err := is.imageStreamGetter.get()
+
 	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.TagIsInsecure: failed to get image stream: %v", err)
-		return false, err
+		return false, convertImageStreamGetterError(err, fmt.Sprintf("TagIsInsecure: failed to get image stream %s", is.Reference()))
 	}
 
 	if insecure, _ := stream.Annotations[imageapi.InsecureRepositoryAnnotation]; insecure == "true" {
@@ -248,37 +256,38 @@ func (is *imageStream) TagIsInsecure(ctx context.Context, tag string, dgst diges
 	return false, nil
 }
 
-func (is *imageStream) Exists(ctx context.Context) (bool, error) {
-	_, err := is.imageStreamGetter.get()
-	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.Exists: failed to get image stream: %v", err)
-		if t, ok := err.(errcode.Error); ok && t.ErrorCode() == disterrors.ErrorCodeNameUnknown {
+func (is *imageStream) Exists(ctx context.Context) (bool, *rerrors.Error) {
+	_, rErr := is.imageStreamGetter.get()
+	if rErr != nil {
+		if rErr.Code == ErrImageStreamGetterNotFoundCode {
 			return false, nil
 		}
-		return false, err
+		return false, convertImageStreamGetterError(rErr, fmt.Sprintf("Exists: failed to get image stream %s", is.Reference()))
 	}
 	return true, nil
 }
 
-func (is *imageStream) localRegistry(ctx context.Context) (string, error) {
-	stream, err := is.imageStreamGetter.get()
-	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.localRegistry: failed to get image stream: %v", err)
-		return "", err
+func (is *imageStream) localRegistry(ctx context.Context) (string, *rerrors.Error) {
+	stream, rErr := is.imageStreamGetter.get()
+	if rErr != nil {
+		return "", convertImageStreamGetterError(rErr, fmt.Sprintf("localRegistry: failed to get image stream %s", is.Reference()))
 	}
 
 	local, err := imageapi.ParseDockerImageReference(stream.Status.DockerImageRepository)
 	if err != nil {
-		return "", err
+		return "", rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("localRegistry: unable to parse reference %q", stream.Status.DockerImageRepository),
+			err,
+		)
 	}
 	return local.Registry, nil
 }
 
-func (is *imageStream) IdentifyCandidateRepositories(ctx context.Context, primary bool) ([]string, map[string]ImagePullthroughSpec, error) {
+func (is *imageStream) IdentifyCandidateRepositories(ctx context.Context, primary bool) ([]string, map[string]ImagePullthroughSpec, *rerrors.Error) {
 	stream, err := is.imageStreamGetter.get()
 	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.IdentifyCandidateRepositories: failed to get image stream: %v", err)
-		return nil, nil, err
+		return nil, nil, convertImageStreamGetterError(err, fmt.Sprintf("IdentifyCandidateRepositories: failed to get image stream %s", is.Reference()))
 	}
 
 	localRegistry, _ := is.localRegistry(ctx)
@@ -287,11 +296,10 @@ func (is *imageStream) IdentifyCandidateRepositories(ctx context.Context, primar
 	return repositoryCandidates, search, nil
 }
 
-func (is *imageStream) Tags(ctx context.Context) (map[string]digest.Digest, error) {
+func (is *imageStream) Tags(ctx context.Context) (map[string]digest.Digest, *rerrors.Error) {
 	stream, err := is.imageStreamGetter.get()
 	if err != nil {
-		context.GetLogger(ctx).Errorf("imageStream.Tags: failed to get image stream: %v", err)
-		return nil, err
+		return nil, convertImageStreamGetterError(err, fmt.Sprintf("Tags: failed to get image stream %s", is.Reference()))
 	}
 
 	m := make(map[string]digest.Digest)
@@ -315,7 +323,7 @@ func (is *imageStream) Tags(ctx context.Context) (map[string]digest.Digest, erro
 	return m, nil
 }
 
-func (is *imageStream) CreateImageStreamMapping(ctx context.Context, userClient client.Interface, tag string, image *imageapiv1.Image) error {
+func (is *imageStream) CreateImageStreamMapping(ctx context.Context, userClient client.Interface, tag string, image *imageapiv1.Image) *rerrors.Error {
 	ism := imageapiv1.ImageStreamMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: is.namespace,
@@ -325,53 +333,98 @@ func (is *imageStream) CreateImageStreamMapping(ctx context.Context, userClient 
 		Tag:   tag,
 	}
 
-	if _, err := is.registryOSClient.ImageStreamMappings(is.namespace).Create(&ism); err != nil {
-		// if the error was that the image stream wasn't found, try to auto provision it
-		statusErr, ok := err.(*kerrors.StatusError)
-		if !ok {
-			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping: %s", err)
-			return err
-		}
+	_, err := is.registryOSClient.ImageStreamMappings(is.namespace).Create(&ism)
 
-		if quotautil.IsErrorQuotaExceeded(statusErr) {
-			context.GetLogger(ctx).Errorf("quota exceeded during creation of ImageStreamMapping: %v", statusErr)
-			return distribution.ErrAccessDenied
-		}
+	if err == nil {
+		return nil
+	}
 
-		status := statusErr.ErrStatus
-		isValidKind := false
-		if status.Details != nil {
-			switch strings.ToLower(status.Details.Kind) {
-			case "imagestream", /*pre-1.2*/
-				"imagestreams", /*1.2 to 1.6*/
-				"imagestreammappings" /*1.7+*/ :
-				isValidKind = true
-			}
-		}
-		if !isValidKind || status.Code != http.StatusNotFound || status.Details.Name != is.name {
-			context.GetLogger(ctx).Errorf("error creation of ImageStreamMapping: %s", err)
-			return err
-		}
+	if quotautil.IsErrorQuotaExceeded(err) {
+		return rerrors.NewError(
+			ErrImageStreamForbiddenCode,
+			fmt.Sprintf("CreateImageStreamMapping: quota exceeded during creation of %s ImageStreamMapping", is.Reference()),
+			err,
+		)
+	}
 
-		if _, err := is.createImageStream(ctx, userClient); err != nil {
-			return err
-		}
+	// if the error was that the image stream wasn't found, try to auto provision it
+	statusErr, ok := err.(*kerrors.StatusError)
+	if !ok {
+		return rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("CreateImageStreamMapping: error creating %s ImageStreamMapping", is.Reference()),
+			err,
+		)
+	}
 
-		// try to create the ISM again
-		if _, err := is.registryOSClient.ImageStreamMappings(is.namespace).Create(&ism); err != nil {
-			if quotautil.IsErrorQuotaExceeded(err) {
-				context.GetLogger(ctx).Errorf("quota exceeded during creation of ImageStreamMapping second time: %v", err)
-				return distribution.ErrAccessDenied
-			}
-			context.GetLogger(ctx).Errorf("error creating ImageStreamMapping second time: %s", err)
-			return err
+	status := statusErr.ErrStatus
+	isValidKind := false
+
+	if status.Details != nil {
+		switch strings.ToLower(status.Details.Kind) {
+		case "imagestream", /*pre-1.2*/
+			"imagestreams", /*1.2 to 1.6*/
+			"imagestreammappings" /*1.7+*/ :
+			isValidKind = true
 		}
 	}
-	return nil
+	if !isValidKind || status.Code != http.StatusNotFound || status.Details.Name != is.name {
+		return rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("CreateImageStreamMapping: error creation of %s ImageStreamMapping", is.Reference()),
+			err,
+		)
+	}
+
+	stream := &imageapiv1.ImageStream{}
+	stream.Name = is.name
+
+	_, err = userClient.ImageStreams(is.namespace).Create(stream)
+
+	switch {
+	case kerrors.IsAlreadyExists(err), kerrors.IsConflict(err):
+		// It is ok.
+	case kerrors.IsForbidden(err), kerrors.IsUnauthorized(err), quotautil.IsErrorQuotaExceeded(err):
+		return rerrors.NewError(
+			ErrImageStreamForbiddenCode,
+			fmt.Sprintf("CreateImageStreamMapping: denied creating ImageStream %s", is.Reference()),
+			err,
+		)
+	case err != nil:
+		return rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("CreateImageStreamMapping: error auto provisioning ImageStream %s", is.Reference()),
+			err,
+		)
+	}
+
+	context.GetLogger(ctx).Debugf("cache image stream %s/%s", stream.Namespace, stream.Name)
+	is.imageStreamGetter.cacheImageStream(stream)
+
+	// try to create the ISM again
+	_, err = is.registryOSClient.ImageStreamMappings(is.namespace).Create(&ism)
+
+	if err == nil {
+		return nil
+	}
+
+	if quotautil.IsErrorQuotaExceeded(err) {
+		return rerrors.NewError(
+			ErrImageStreamForbiddenCode,
+			fmt.Sprintf("CreateImageStreamMapping: quota exceeded during creation of %s ImageStreamMapping second time", is.Reference()),
+			err,
+		)
+	}
+
+	return rerrors.NewError(
+		ErrImageStreamUnknownErrorCode,
+		fmt.Sprintf("CreateImageStreamMapping: error creating %s ImageStreamMapping second time", is.Reference()),
+		err,
+	)
 }
 
 // GetLimitRangeList returns list of limit ranges for repo.
-func (is *imageStream) GetLimitRangeList(ctx context.Context, cache ProjectObjectListStore) (*corev1.LimitRangeList, error) {
+func (is *imageStream) GetLimitRangeList(ctx context.Context, cache ProjectObjectListStore) (*corev1.LimitRangeList, *rerrors.Error) {
 	if cache != nil {
 		obj, exists, _ := cache.Get(is.namespace)
 		if exists {
@@ -383,16 +436,32 @@ func (is *imageStream) GetLimitRangeList(ctx context.Context, cache ProjectObjec
 
 	lrs, err := is.registryOSClient.LimitRanges(is.namespace).List(metav1.ListOptions{})
 	if err != nil {
-		context.GetLogger(ctx).Errorf("failed to list limitranges: %v", err)
-		return nil, err
+		return nil, rerrors.NewError(
+			ErrImageStreamUnknownErrorCode,
+			fmt.Sprintf("GetLimitRangeList: failed to list limitranges for %s", is.Reference()),
+			err,
+		)
 	}
 
 	if cache != nil {
 		err = cache.Add(is.namespace, lrs)
 		if err != nil {
-			context.GetLogger(ctx).Errorf("failed to cache limit range list: %v", err)
+			context.GetLogger(ctx).Errorf("GetLimitRangeList: failed to cache limit range list: %v", err)
 		}
 	}
 
 	return lrs, nil
+}
+
+func convertImageStreamGetterError(err *rerrors.Error, msg string) *rerrors.Error {
+	code := ErrImageStreamUnknownErrorCode
+
+	switch err.Code {
+	case ErrImageStreamGetterNotFoundCode:
+		code = ErrImageStreamNotFoundCode
+	case ErrImageStreamGetterForbiddenCode:
+		code = ErrImageStreamForbiddenCode
+	}
+
+	return rerrors.NewError(code, msg, err)
 }

--- a/pkg/imagestream/imagestreamhasblob.go
+++ b/pkg/imagestream/imagestreamhasblob.go
@@ -40,7 +40,7 @@ func (is *imageStream) HasBlob(ctx context.Context, dgst digest.Digest) *imageap
 	// verify directly with etcd
 	stream, err := is.imageStreamGetter.get()
 	if err != nil {
-		context.GetLogger(ctx).Errorf("failed to get image stream: %v", err)
+		context.GetLogger(ctx).Errorf("imageStream.HasBlob: failed to get image stream: %v", err)
 		return logFound(nil)
 	}
 

--- a/pkg/imagestream/imagestreamhasblob.go
+++ b/pkg/imagestream/imagestreamhasblob.go
@@ -8,8 +8,6 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/manifest/schema2"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/openshift/api/image/docker10"
 	imageapiv1 "github.com/openshift/api/image/v1"
 )
@@ -79,7 +77,7 @@ func (is *imageStream) HasBlob(ctx context.Context, dgst digest.Digest) *imageap
 		context.GetLogger(ctx).Debugf("getting image %s", tagEvent.Image)
 		image, err := is.getImage(ctx, digest.Digest(tagEvent.Image))
 		if err != nil {
-			if kerrors.IsNotFound(err) {
+			if err.Code == ErrImageStreamImageNotFoundCode {
 				context.GetLogger(ctx).Debugf("image %q not found", tagEvent.Image)
 			} else {
 				context.GetLogger(ctx).Errorf("failed to get image: %v", err)

--- a/vendor/github.com/docker/distribution/registry/handlers/app.go
+++ b/vendor/github.com/docker/distribution/registry/handlers/app.go
@@ -779,7 +779,18 @@ func (app *App) logError(context context.Context, errors errcode.Errors) {
 			errCodeKey{},
 			errMessageKey{},
 			errDetailKey{}))
-		ctxu.GetResponseLogger(c).Errorf("response completed with error")
+
+		logf := ctxu.GetResponseLogger(c).Errorf
+
+		httpStatus, ok := c.Value("http.response.status").(int)
+		if ok && httpStatus == 404 {
+			httpMethod, ok := c.Value("http.request.method").(string)
+			if ok && strings.ToLower(httpMethod) == "head" {
+				logf = ctxu.GetResponseLogger(c).Infof
+			}
+		}
+
+		logf("response completed with error")
 	}
 }
 

--- a/vendor/github.com/docker/distribution/registry/storage/filereader_test.go
+++ b/vendor/github.com/docker/distribution/registry/storage/filereader_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/distribution/context"
 	"github.com/docker/distribution/digest"
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
 	"github.com/docker/distribution/registry/storage/driver/inmemory"
 )
 
@@ -159,22 +160,18 @@ func TestFileReaderSeek(t *testing.T) {
 // missing or zero-length remote file. While the file may not exist, the
 // reader should not error out on creation and should return 0-bytes from the
 // read method, with an io.EOF error.
+// Not.
+// This logic is defective by design. We have not seen such race conditions.
+// On the other hand, a situation where instead of a blob an empty response
+// is returned is quite common (if you allow blob deletion).
 func TestFileReaderNonExistentFile(t *testing.T) {
 	driver := inmemory.New()
-	fr, err := newFileReader(context.Background(), driver, "/doesnotexist", 10)
-	if err != nil {
-		t.Fatalf("unexpected error initializing reader: %v", err)
+	_, err := newFileReader(context.Background(), driver, "/doesnotexist", 10)
+	if err == nil {
+		t.Fatal("unexpected successful result")
 	}
-
-	var buf [1024]byte
-
-	n, err := fr.Read(buf[:])
-	if n != 0 {
-		t.Fatalf("non-zero byte read reported: %d != 0", n)
-	}
-
-	if err != io.EOF {
-		t.Fatalf("read on missing file should return io.EOF, got %v", err)
+	if _, ok := err.(storagedriver.PathNotFoundError); !ok {
+		t.Fatalf("read on missing file should return storagedriver.PathNotFoundError, got %v", err)
 	}
 }
 


### PR DESCRIPTION
**New error policy**
    
* Internal modules return only their own errors. All downstream errors are converted. In this case, the module needs to check only `N-1` level errors.
    
* Do not convert errors from internal functions. They must return the correct errors.
    
* When converting an error with loss of context, it is necessary to write the previous error to log.

@dmage PTAL