### PR TITLE
[WIP] Do not store layer links in the repository

### DIFF
--- a/pkg/dockerregistry/server/app.go
+++ b/pkg/dockerregistry/server/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/cache"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/client"
 	registryconfig "github.com/openshift/image-registry/pkg/dockerregistry/server/configuration"
+	"github.com/openshift/image-registry/pkg/dockerregistry/server/linklessdriver"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/maxconnections"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/metrics"
 	"github.com/openshift/image-registry/pkg/dockerregistry/server/supermiddleware"
@@ -72,7 +73,7 @@ type App struct {
 }
 
 func (app *App) Storage(driver storagedriver.StorageDriver, options map[string]interface{}) (storagedriver.StorageDriver, error) {
-	app.driver = app.metrics.StorageDriver(driver)
+	app.driver = app.metrics.StorageDriver(linklessdriver.StorageDriver(driver))
 	return app.driver, nil
 }
 

--- a/pkg/dockerregistry/server/blobdescriptorservice.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice.go
@@ -37,15 +37,7 @@ type blobDescriptorService struct {
 func (bs *blobDescriptorService) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
 	dcontext.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: starting with digest=%s", dgst.String())
 
-	// if there is a repo layer link, return its descriptor
-	desc, err := bs.BlobDescriptorService.Stat(ctx, dgst)
-	if err == nil {
-		return desc, nil
-	}
-	dcontext.GetLogger(ctx).Debugf("(*blobDescriptorService).Stat: could not stat layer link %s in repository %s: %v", dgst.String(), bs.repo.Named().Name(), err)
-
-	// we couldn't find the layer link
-	desc, err = bs.repo.app.BlobStatter().Stat(ctx, dgst)
+	desc, err := bs.repo.app.BlobStatter().Stat(ctx, dgst)
 	if err != nil {
 		return desc, err
 	}

--- a/pkg/dockerregistry/server/linklessdriver/doc.go
+++ b/pkg/dockerregistry/server/linklessdriver/doc.go
@@ -1,0 +1,2 @@
+// Package linklessdriver contains storage driver middleware to ignore layer and manifest links in a repository.
+package linklessdriver

--- a/pkg/dockerregistry/server/linklessdriver/linklessdriver.go
+++ b/pkg/dockerregistry/server/linklessdriver/linklessdriver.go
@@ -1,0 +1,62 @@
+package linklessdriver
+
+import (
+	"context"
+	"strings"
+
+	storagedriver "github.com/docker/distribution/registry/storage/driver"
+)
+
+type nullWriter struct {
+	size int64
+}
+
+var _ storagedriver.FileWriter = &nullWriter{}
+
+func (w *nullWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	w.size += int64(n)
+	return
+}
+
+func (w *nullWriter) Close() error {
+	return nil
+}
+
+func (w *nullWriter) Cancel() error {
+	return nil
+}
+
+func (w *nullWriter) Commit() error {
+	return nil
+}
+
+func (w *nullWriter) Size() int64 {
+	return w.size
+}
+
+type linklessStorageDriver struct {
+	storagedriver.StorageDriver
+}
+
+var _ storagedriver.StorageDriver = &linklessStorageDriver{}
+
+func StorageDriver(driver storagedriver.StorageDriver) storagedriver.StorageDriver {
+	return &linklessStorageDriver{
+		StorageDriver: driver,
+	}
+}
+
+func (l *linklessStorageDriver) PutContent(ctx context.Context, path string, content []byte) error {
+	if strings.HasSuffix(path, "/link") {
+		return nil
+	}
+	return l.StorageDriver.PutContent(ctx, path, content)
+}
+
+func (l *linklessStorageDriver) Writer(ctx context.Context, path string, append bool) (storagedriver.FileWriter, error) {
+	if strings.HasSuffix(path, "/link") {
+		return &nullWriter{}, nil
+	}
+	return l.StorageDriver.Writer(ctx, path, append)
+}


### PR DESCRIPTION
There are several ways to lose links in the repository. User can delete imagestreamtag or whole imagestream from etcd. So the `oc prune image` will not help here (only hardprune can help when it learns to remove them). At the same time, links are involved in access control. To avoid possible harm, we must always use the information from the etcd to resolve links. We have a global descriptor cache so we will not constantly access to master api.
