### PR TITLE
Reduce cardinality of metrics, use summary instead of histograms

### DIFF
--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -26,7 +26,7 @@ type Counter interface {
 
 // Sink provides an interface for exposing metrics.
 type Sink interface {
-	RequestDuration(funcname, reponame string) Observer
+	RequestDuration(funcname string) Observer
 	PullthroughBlobstoreCacheRequests(resultType string) Counter
 	PullthroughRepositoryDuration(registry, funcname string) Observer
 	PullthroughRepositoryErrors(registry, funcname, errcode string) Counter
@@ -148,7 +148,7 @@ func NewMetrics(sink Sink) Metrics {
 
 func (m *metrics) Repository(r distribution.Repository, reponame string) distribution.Repository {
 	return wrapped.NewRepository(r, func(ctx context.Context, funcname string, f func(ctx context.Context) error) error {
-		defer NewTimer(m.sink.RequestDuration(funcname, reponame)).Stop()
+		defer NewTimer(m.sink.RequestDuration(funcname)).Stop()
 		return f(ctx)
 	})
 }

--- a/pkg/dockerregistry/server/metrics/prometheus.go
+++ b/pkg/dockerregistry/server/metrics/prometheus.go
@@ -18,13 +18,13 @@ const (
 )
 
 var (
-	requestDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	requestDurationSeconds = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Name:      "request_duration_seconds",
 			Help:      "Request latency in seconds for each operation.",
 		},
-		[]string{"operation", "name"},
+		[]string{"operation"},
 	)
 
 	HTTPInFlightRequests = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -42,43 +42,39 @@ var (
 		},
 		[]string{"code", "method"},
 	)
-	HTTPRequestDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	HTTPRequestDurationSeconds = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: httpSubsystem,
 			Name:      "request_duration_seconds",
 			Help:      "A histogram of latencies for requests to the registry.",
-			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
 		[]string{"method"},
 	)
-	HTTPRequestSizeBytes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	HTTPRequestSizeBytes = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: httpSubsystem,
 			Name:      "request_size_bytes",
 			Help:      "A histogram of sizes of requests to the registry.",
-			Buckets:   []float64{100, 200, 500, 1300, 3400, 8900},
 		},
 		[]string{},
 	)
-	HTTPResponseSizeBytes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	HTTPResponseSizeBytes = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: httpSubsystem,
 			Name:      "response_size_bytes",
 			Help:      "A histogram of response sizes for requests to the registry.",
-			Buckets:   []float64{100, 200, 500, 1300, 3400, 8900},
 		},
 		[]string{},
 	)
-	HTTPTimeToWriteHeaderSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	HTTPTimeToWriteHeaderSeconds = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: httpSubsystem,
 			Name:      "time_to_write_header_seconds",
 			Help:      "A histogram of request durations until the response headers are written.",
-			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
 		[]string{},
 	)
@@ -92,13 +88,12 @@ var (
 		},
 		[]string{"type"},
 	)
-	pullthroughRepositoryDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	pullthroughRepositoryDurationSeconds = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: pullthroughSubsystem,
 			Name:      "repository_duration_seconds",
 			Help:      "Latency of operations with remote registries in seconds.",
-			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
 		[]string{"registry", "operation"},
 	)
@@ -112,13 +107,12 @@ var (
 		[]string{"registry", "operation", "code"},
 	)
 
-	storageDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	storageDurationSeconds = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: namespace,
 			Subsystem: storageSubsystem,
 			Name:      "duration_seconds",
 			Help:      "Latency of operations with the storage.",
-			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
 		[]string{"operation"},
 	)
@@ -179,8 +173,8 @@ func NewPrometheusSink() Sink {
 	return prometheusSink{}
 }
 
-func (s prometheusSink) RequestDuration(funcname, reponame string) Observer {
-	return requestDurationSeconds.WithLabelValues(funcname, reponame)
+func (s prometheusSink) RequestDuration(funcname string) Observer {
+	return requestDurationSeconds.WithLabelValues(funcname)
 }
 
 func (s prometheusSink) PullthroughBlobstoreCacheRequests(resultType string) Counter {

--- a/pkg/dockerregistry/server/metrics/testing/counter.go
+++ b/pkg/dockerregistry/server/metrics/testing/counter.go
@@ -25,9 +25,9 @@ type counterSink struct {
 
 var _ metrics.Sink = &counterSink{}
 
-func (s counterSink) RequestDuration(funcname, reponame string) metrics.Observer {
+func (s counterSink) RequestDuration(funcname string) metrics.Observer {
 	return callbackObserver(func(float64) {
-		s.c.Add(fmt.Sprintf("request:%s:%s", funcname, reponame), 1)
+		s.c.Add(fmt.Sprintf("request:%s", funcname), 1)
 	})
 }
 

--- a/test/integration/metricspullthrough/metricspullthrough_test.go
+++ b/test/integration/metricspullthrough/metricspullthrough_test.go
@@ -122,7 +122,7 @@ func TestPullthroughBlob(t *testing.T) {
 		values []string
 	}{
 		{
-			name:   "imageregistry_storage_duration_seconds_bucket",
+			name:   "imageregistry_storage_duration_seconds",
 			values: []string{`operation="StorageDriver.Stat"`},
 		},
 		{
@@ -138,7 +138,7 @@ func TestPullthroughBlob(t *testing.T) {
 			values: []string{`type="Miss"`},
 		},
 		{
-			name:   "imageregistry_pullthrough_repository_duration_seconds_bucket",
+			name:   "imageregistry_pullthrough_repository_duration_seconds",
 			values: []string{`operation="Init"`},
 		},
 	}


### PR DESCRIPTION
The repo latency metrics could have extremely high cardinality, so without
a definite use case let's remove it. Instead of Histograms, use Summaries
which simplify buckets and make visualization easier.