### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check: verify test-unit test-integration
 #
 # Example:
 #   make verify
-verify: verify-fmt verify-govet verify-imports verify-gometalinter
+verify: verify-fmt verify-govet verify-imports verify-gometalinter verify-sec
 .PHONY: verify
 
 verify-fmt:
@@ -66,6 +66,11 @@ verify-govet:
 verify-imports:
 	hack/verify-imports.sh
 .PHONY: verify-imports
+
+verify-sec:
+	go get -u github.com/securego/gosec/cmd/gosec
+	gosec -severity medium -confidence medium -exclude G304 -quiet ./...
+.PHONY: verify-sec
 
 LOGFUNCS=Debug Info Warn Warning Error
 null  :=

--- a/pkg/testframework/httptest.go
+++ b/pkg/testframework/httptest.go
@@ -22,6 +22,9 @@ func NewHTTPServer(t *testing.T, handler http.Handler) *HTTPServer {
 		t.Fatal(err)
 	}
 
+	// #nosec
+	// This is part of the test framework; so it's fine it listens on all
+	// interfaces.
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/testframework/master.go
+++ b/pkg/testframework/master.go
@@ -70,6 +70,8 @@ func (p *MasterProcess) WaitHealthz(configDir string) error {
 	if err != nil {
 		return err
 	}
+	// #nosec
+	// This is art of the test framework; so no need to verify.
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}

--- a/pkg/testframework/net.go
+++ b/pkg/testframework/net.go
@@ -44,6 +44,9 @@ func DefaultLocalIP4() (net.IP, error) {
 //
 // k8s.io/kubernetes/test/integration/framework.FindFreeLocalPort
 func FindFreeLocalPort() (int, error) {
+	// #nosec
+	// This is part of the test framework; so it's fine it listens on all
+	// interfaces.
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return 0, err

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -285,6 +285,8 @@ func (tcs *testCredentialStore) SetRefreshToken(u *url.URL, service string, toke
 // ping pings the provided endpoint to determine its required authorization challenges.
 // If a version header is provided, the versions will be returned.
 func ping(manager challenge.Manager, endpoint, versionHeader string) ([]auth.APIVersion, error) {
+	// #nosec
+	// Only used for testing.
 	resp, err := http.Get(endpoint)
 	if err != nil {
 		return nil, err

--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -319,6 +319,8 @@ func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
 func resolvePackage(targetPackage string) ([]Package, error) {
 	cmd := "go"
 	args := []string{"list", "-json", targetPackage}
+	// #nosec
+	// This merely calls go list; It's not a security issue.
 	stdout, err := exec.Command(cmd, args...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("Failed to run `%s %s`: %v\n", cmd, strings.Join(args, " "), err)


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.
    
This PR introduces the tool, and sets it up as a test target in the Makefile.
