### PR TITLE
Disabled pprof and marking exec() as safe.

### DIFF
--- a/cmd/dockerregistry/main.go
+++ b/cmd/dockerregistry/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"time"

--- a/tools/changelog/changelog.go
+++ b/tools/changelog/changelog.go
@@ -85,6 +85,7 @@ func main() {
 	from := os.Args[1]
 	to := os.Args[2]
 
+	// #nosec
 	out, err := exec.Command("git", "log", "--topo-order", "--pretty=tformat:%h %p|%s", "--reverse", fmt.Sprintf("%s..%s", from, to)).CombinedOutput()
 	if err != nil {
 		log.Fatal(err)
@@ -148,6 +149,7 @@ func main() {
 		}
 
 		// try to find either the PR title or the first commit title from the merge commit
+		// #nosec
 		out, err := exec.Command("git", "show", "--pretty=tformat:%b", c.short).CombinedOutput()
 		if err != nil {
 			log.Fatal(err)
@@ -255,6 +257,7 @@ func findPrefixFor(message string, commits []commit) (string, bool) {
 }
 
 func hasFileChanges(commit string, prefixes ...string) bool {
+	// #nosec
 	out, err := exec.Command("git", "diff", "--name-only", fmt.Sprintf("%s^..%s", commit, commit)).CombinedOutput()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
gosec is complaining about two issues. One is that we have pprof enabled
on our process and the other is about using variables when shelling out
commands. As far as I have checked there is no potential harm in using
exec the way we are using as command line arguments are properly escaped
before shelling out.

As for pprof, this patch disables it.


This is to fix problems during CI as this:

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_image-registry/194/pull-ci-openshift-image-registry-master-verify/11