### PR TITLE
Disabled gosec.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ check: verify test-unit test-integration
 #
 # Example:
 #   make verify
-verify: verify-fmt verify-govet verify-imports verify-sec
+verify: verify-fmt verify-govet verify-imports
 .PHONY: verify
 
 verify-fmt:
@@ -66,11 +66,6 @@ verify-govet:
 verify-imports:
 	hack/verify-imports.sh
 .PHONY: verify-imports
-
-verify-sec:
-	go get -u github.com/securego/gosec/cmd/gosec
-	gosec -severity medium -confidence medium -exclude G304 -quiet ./...
-.PHONY: verify-sec
 
 LOGFUNCS=Debug Info Warn Warning Error
 null  :=


### PR DESCRIPTION
We are disabling this tool for now. With **gosec** our tests are constantly failing and that is delaying us of getting what has been planned for the sprint done. We will revisit this in the future and there is already a ticket in place to do so.

Regarding the four security flaws reported by **gosec** on this repo:
1. Three of them are not critical(using variables when "shelling out" commands)
2. One of them is related to the fact we have profiling(pprof) enabled on the registry.

For item number 1 I have checked and the variables being used when shelling out won't cause any problem as the user can't tamper with them. As for the second, to have profiling enabled is mandatory, further checks for alternatives could be done when we start working on it.

For reference, the ticket is https://jira.coreos.com/browse/DEVEXP-437