### PR TITLE
Don't use Go-syntax representation for errors

### DIFF
--- a/pkg/dockerregistry/server/pullthroughblobstore.go
+++ b/pkg/dockerregistry/server/pullthroughblobstore.go
@@ -40,7 +40,7 @@ func (pbs *pullthroughBlobStore) Stat(ctx context.Context, dgst digest.Digest) (
 		// continue on to the code below and look up the blob in a remote store since it is not in
 		// the local store
 	case err != nil:
-		dcontext.GetLogger(ctx).Errorf("unable to find blob %q: %#v", dgst.String(), err)
+		dcontext.GetLogger(ctx).Errorf("unable to find blob %s: %v", dgst.String(), err)
 		fallthrough
 	default:
 		return desc, err
@@ -63,7 +63,7 @@ func (pbs *pullthroughBlobStore) ServeBlob(ctx context.Context, w http.ResponseW
 		// continue on to the code below and look up the blob in a remote store since it is not in
 		// the local store
 	case err != nil:
-		dcontext.GetLogger(ctx).Errorf("unable to serve blob %q: %#v", dgst.String(), err)
+		dcontext.GetLogger(ctx).Errorf("unable to serve blob %s: %v", dgst.String(), err)
 		fallthrough
 	default:
 		return err


### PR DESCRIPTION
`%#v` is supposed to provide more detailed information about the problem, but in practice `%#v` makes some error message unusable, for example:

> msg="unable to find blob \\"sha256:7ddcb796f98af1e76313d7655000413483316d2f1cf8dbbda75b8bcb75226405\\": driver.Error{DriverName:\\"swift\\", Enclosed:(*url.Error)(0xc00093b590)}"