### PR TITLE
Add component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - bparees
   - dmage
   - adambkaplan
+component: "Image Registry"


### PR DESCRIPTION
The image registry is associated with the "Image Registry" component in Bugzilla.

/assign @jupierce

/cc @adambkaplan 