### PR TITLE
Bug 1804160: Checking for namespace existence

### DIFF
--- a/pkg/dockerregistry/server/client/client.go
+++ b/pkg/dockerregistry/server/client/client.go
@@ -30,6 +30,7 @@ type Interface interface {
 	ImageStreamTagsNamespacer
 	LimitRangesGetter
 	LocalSubjectAccessReviewsNamespacer
+	NamespaceGetter
 	SelfSubjectAccessReviewsNamespacer
 	UsersInterfacer
 }
@@ -57,6 +58,10 @@ func newAPIClient(
 
 func (c *apiClient) Users() UserInterface {
 	return c.user.Users()
+}
+
+func (c *apiClient) Namespaces() NamespaceInterface {
+	return c.kube.Namespaces()
 }
 
 func (c *apiClient) Images() ImageInterface {

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -25,6 +25,10 @@ type ImagesInterfacer interface {
 	Images() ImageInterface
 }
 
+type NamespaceGetter interface {
+	Namespaces() NamespaceInterface
+}
+
 type ImageSignaturesInterfacer interface {
 	ImageSignatures() ImageSignatureInterface
 }
@@ -80,6 +84,10 @@ type UserInterface interface {
 }
 
 var _ ImageInterface = imageclientv1.ImageInterface(nil)
+
+type NamespaceInterface interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Namespace, error)
+}
 
 type ImageInterface interface {
 	Get(ctx context.Context, name string, opts metav1.GetOptions) (*imageapiv1.Image, error)


### PR DESCRIPTION
By design `docker/distribution` hides any error during auth under a BadRequest[1] so this is clearly not an optimal solution. We can't distinguish between a "non-existent" namespace and a kubernetes api error, in other words: we can't distinguish between a 403 and an 500, everything is a 400 FTW.

Let me know if I should try to patch upstream or I should be doing this validation somewhere else.

[1] https://github.com/docker/distribution/blob/master/registry/handlers/app.go#L844-L864