### PR TITLE
Bug 1921909: vendor in updated openshift/docker-distribution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,6 @@ require (
 )
 
 replace (
-	github.com/docker/distribution => github.com/openshift/docker-distribution v0.0.0-20201012083032-63d38f155de2
+	github.com/docker/distribution => github.com/openshift/docker-distribution v0.0.0-20201201172659-3eb6216fd7ed
 	google.golang.org/api => google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff
 )

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5 h1:E6WhVL5p3rfjtc+o+jVG/29Aclnf3XIF7akxXvadwR0=
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
-github.com/openshift/docker-distribution v0.0.0-20201012083032-63d38f155de2 h1:k61vbnX44HVQab0UTsCAUUHQOPAePC6AdW2yD5ycdB8=
-github.com/openshift/docker-distribution v0.0.0-20201012083032-63d38f155de2/go.mod h1:XmfFzbwryblvZ29NebonirM7RBuNEO7+yVCOapaouAk=
+github.com/openshift/docker-distribution v0.0.0-20201201172659-3eb6216fd7ed h1:tVqsK+HvyEWlfKOdN3EhOjA4HNfkttjjq/uqbbJzugU=
+github.com/openshift/docker-distribution v0.0.0-20201201172659-3eb6216fd7ed/go.mod h1:XmfFzbwryblvZ29NebonirM7RBuNEO7+yVCOapaouAk=
 github.com/openshift/library-go v0.0.0-20200921120329-c803a7b7bb2c h1:mCIAsuMLoUeOJouEa097NZ+O7C+A+PmvSaOniUBDz7g=
 github.com/openshift/library-go v0.0.0-20200921120329-c803a7b7bb2c/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -90,7 +90,7 @@ github.com/denverdino/aliyungo/oss
 github.com/denverdino/aliyungo/util
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible
 github.com/dgrijalva/jwt-go
-# github.com/docker/distribution v0.0.0-20180920194744-16128bbac47f => github.com/openshift/docker-distribution v0.0.0-20201012083032-63d38f155de2
+# github.com/docker/distribution v0.0.0-20180920194744-16128bbac47f => github.com/openshift/docker-distribution v0.0.0-20201201172659-3eb6216fd7ed
 github.com/docker/distribution
 github.com/docker/distribution/configuration
 github.com/docker/distribution/context


### PR DESCRIPTION
This allows setting REGISTRY_STORAGE_S3_CREDENTIALSCONFIGPATH to point to a file containing AWS credentials (instead of setting environment variables containing the credentials).

The registry operator can now chose to mount a Secret/ConfigMap containing an AWS credentials configuration file which should allow using AWS authentication methods besides the (still supported) AWS access and secret keys.