### PR TITLE
Bug 1902456: Fixed incorrect access denied error logs

### DIFF
--- a/pkg/dockerregistry/server/auth.go
+++ b/pkg/dockerregistry/server/auth.go
@@ -62,17 +62,11 @@ type AccessController struct {
 
 var _ registryauth.AccessController = &AccessController{}
 
-type authChallenge struct {
-	realm string
-	err   error
-}
-
-var _ registryauth.Challenge = &authChallenge{}
-
 type tokenAuthChallenge struct {
-	realm   string
-	service string
-	err     error
+	basicRealm  string
+	bearerRealm url.URL
+	service     string
+	err         error
 }
 
 var _ registryauth.Challenge = &tokenAuthChallenge{}
@@ -105,69 +99,59 @@ func (app *App) Auth(options map[string]interface{}) (registryauth.AccessControl
 }
 
 // Error returns the internal error string for this authChallenge.
-func (ac *authChallenge) Error() string {
-	return ac.err.Error()
-}
-
-// SetHeaders sets the basic challenge header on the response.
-func (ac *authChallenge) SetHeaders(req *http.Request, w http.ResponseWriter) {
-	// WWW-Authenticate response challenge header.
-	// See https://tools.ietf.org/html/rfc6750#section-3
-	str := fmt.Sprintf("Basic realm=%s", ac.realm)
-	if ac.err != nil {
-		str = fmt.Sprintf("%s,error=%q", str, ac.Error())
-	}
-	w.Header().Set("WWW-Authenticate", str)
-}
-
-// Error returns the internal error string for this authChallenge.
 func (ac *tokenAuthChallenge) Error() string {
 	return ac.err.Error()
 }
 
-// SetHeaders sets the bearer challenge header on the response.
+// SetHeaders sets the basic and bearer challenge headers on the response.
 func (ac *tokenAuthChallenge) SetHeaders(req *http.Request, w http.ResponseWriter) {
 	// WWW-Authenticate response challenge header.
 	// See https://docs.docker.com/registry/spec/auth/token/#/how-to-authenticate and https://tools.ietf.org/html/rfc6750#section-3
-	str := fmt.Sprintf("Bearer realm=%q", ac.realm)
-	if ac.service != "" {
-		str += fmt.Sprintf(",service=%q", ac.service)
+	str := fmt.Sprintf("Basic realm=%s", ac.basicRealm)
+	if ac.err != nil {
+		str += fmt.Sprintf(",error=%q", ac.Error())
 	}
 	w.Header().Set("WWW-Authenticate", str)
+
+	if ac.bearerRealm.String() != "" {
+		str = fmt.Sprintf("Bearer realm=%q", ac.bearerRealm.String())
+		if ac.err != nil {
+			if ac.err != ErrOpenShiftAccessDenied {
+				str += fmt.Sprintf(",error=%q", ac.Error())
+			} else {
+				str += fmt.Sprintf(",error=%q", "insufficient_scope")
+			}
+		}
+		if ac.service != "" {
+			str += fmt.Sprintf(",service=%q", ac.service)
+		}
+		w.Header().Add("WWW-Authenticate", str)
+	}
 }
 
 // wrapErr wraps errors related to authorization in an authChallenge error that will present a WWW-Authenticate challenge response
 func (ac *AccessController) wrapErr(ctx context.Context, err error) error {
-	switch err {
-	case ErrTokenRequired:
-		// Challenge for errors that involve missing tokens
-		if ac.tokenRealm == nil {
-			// Send the basic challenge if we don't have a place to redirect
-			return &authChallenge{realm: ac.realm, err: err}
-		}
-
-		if len(ac.tokenRealm.Scheme) > 0 && len(ac.tokenRealm.Host) > 0 {
-			// Redirect to token auth if we've been given an absolute URL
-			return &tokenAuthChallenge{realm: ac.tokenRealm.String(), err: err}
-		}
-
+	var tokenRealmCopy url.URL
+	if ac.tokenRealm != nil {
 		// Auto-detect scheme/host from request
 		req, reqErr := dcontext.GetRequest(ctx)
 		if reqErr != nil {
 			return reqErr
 		}
 		scheme, host := httprequest.SchemeHost(req)
-		tokenRealmCopy := *ac.tokenRealm
+		tokenRealmCopy = *ac.tokenRealm
 		if len(tokenRealmCopy.Scheme) == 0 {
 			tokenRealmCopy.Scheme = scheme
 		}
 		if len(tokenRealmCopy.Host) == 0 {
 			tokenRealmCopy.Host = host
 		}
-		return &tokenAuthChallenge{realm: tokenRealmCopy.String(), err: err}
-	case ErrTokenInvalid, ErrOpenShiftAccessDenied:
-		// Challenge for errors that involve tokens or access denied
-		return &authChallenge{realm: ac.realm, err: err}
+	}
+
+	switch err {
+	case ErrTokenRequired, ErrTokenInvalid, ErrOpenShiftAccessDenied:
+		// Challenges for errors that involve tokens or access denied
+		return &tokenAuthChallenge{basicRealm: ac.realm, bearerRealm: tokenRealmCopy, err: err}
 	default:
 		// By default, just return the error, this gets surfaced as a bad request / internal error, but no challenge
 		return err

--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -129,7 +129,7 @@ func TestAccessController(t *testing.T) {
 			basicToken:        "",
 			expectedError:     ErrTokenRequired,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Bearer realm="http://tokenrealm.com/openshift/token"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="authorization header required"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="authorization header required"`}},
 		},
 		"no token, autodetected tokenrealm": {
 			authConfig: &configuration.Auth{
@@ -140,7 +140,7 @@ func TestAccessController(t *testing.T) {
 			basicToken:        "",
 			expectedError:     ErrTokenRequired,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Bearer realm="https://openshift-example.com/openshift/token"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="authorization header required"`, `Bearer realm="https://openshift-example.com/openshift/token",error="authorization header required"`}},
 		},
 		"invalid registry token": {
 			access: []auth.Access{{
@@ -149,7 +149,7 @@ func TestAccessController(t *testing.T) {
 			basicToken:        "ab-cd-ef-gh",
 			expectedError:     ErrTokenInvalid,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="failed to decode credentials"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="failed to decode credentials"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="failed to decode credentials"`}},
 		},
 		"invalid openshift basic password": {
 			access: []auth.Access{{
@@ -158,7 +158,7 @@ func TestAccessController(t *testing.T) {
 			basicToken:        "abcdefgh",
 			expectedError:     ErrTokenInvalid,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="failed to decode credentials"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="failed to decode credentials"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="failed to decode credentials"`}},
 		},
 		"valid openshift token but invalid namespace": {
 			access: []auth.Access{{
@@ -216,7 +216,7 @@ func TestAccessController(t *testing.T) {
 			openshiftResponses: []response{{403, ""}},
 			expectedError:      ErrOpenShiftAccessDenied,
 			expectedChallenge:  true,
-			expectedHeaders:    http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
+			expectedHeaders:    http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="insufficient_scope"`}},
 			expectedActions:    []string{"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)"},
 		},
 		"docker login with valid openshift creds": {
@@ -263,7 +263,7 @@ func TestAccessController(t *testing.T) {
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="insufficient_scope"`}},
 			expectedActions: []string{
 				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
 				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",
@@ -287,7 +287,7 @@ func TestAccessController(t *testing.T) {
 			},
 			expectedError:     ErrOpenShiftAccessDenied,
 			expectedChallenge: true,
-			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`}},
+			expectedHeaders:   http.Header{"Www-Authenticate": []string{`Basic realm=myrealm,error="access denied"`, `Bearer realm="http://tokenrealm.com/openshift/token",error="insufficient_scope"`}},
 			expectedActions: []string{
 				"GET /apis/user.openshift.io/v1/users/~ (Authorization=Bearer awesome)",
 				"POST /apis/authorization.k8s.io/v1/selfsubjectaccessreviews (Authorization=Bearer awesome)",


### PR DESCRIPTION
Modified challenges for token involved errors with appropriate error from [distribution code](https://github.com/distribution/distribution/blob/main/registry/client/errors.go#L109-L113), so access denied error would cause appropriate error logs. 