### PR TITLE
Fix security context for test pods

### DIFF
--- a/pkg/testframework/registry.go
+++ b/pkg/testframework/registry.go
@@ -294,6 +294,9 @@ func CreateEphemeralRegistry(t *testing.T, restConfig *rest.Config, namespace st
 		)
 	}
 
+	falseVal := false
+	trueVal := true
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -336,6 +339,16 @@ func CreateEphemeralRegistry(t *testing.T, restConfig *rest.Config, namespace st
 						},
 					},
 					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseVal,
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: &trueVal,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			},
 			Volumes: volumes,


### PR DESCRIPTION
The new default pod security policy in OCP is very restrictive and it requires security contexts to have proper values.

Fixes CI failures like https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_image-registry/341/pull-ci-openshift-image-registry-master-e2e-agnostic-image-registry/1560248522756853760