### PR TITLE
OCPBUGS-33453: Use SAR instead of SSAR [wip]

### DIFF
--- a/pkg/dockerregistry/server/auth_test.go
+++ b/pkg/dockerregistry/server/auth_test.go
@@ -91,7 +91,7 @@ func TestVerifyImageStreamAccess(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = verifyImageStreamAccess(ctx, "foo", "bar", "create", osclient)
+		err = verifyImageStreamAccess(ctx, "foo", "bar", "create", osclient, osclient)
 		if err == nil || test.expectedError == nil {
 			if err != test.expectedError {
 				t.Fatalf("verifyImageStreamAccess did not get expected error - got %s - expected %s", err, test.expectedError)

--- a/pkg/dockerregistry/server/client/client.go
+++ b/pkg/dockerregistry/server/client/client.go
@@ -33,6 +33,7 @@ type Interface interface {
 	LimitRangesGetter
 	LocalSubjectAccessReviewsNamespacer
 	SelfSubjectAccessReviewsNamespacer
+	SubjectAccessReviewsNamespacer
 	UsersInterfacer
 	ImageContentSourcePolicyInterfacer
 }
@@ -118,6 +119,10 @@ func (c *apiClient) LocalSubjectAccessReviews(namespace string) LocalSubjectAcce
 
 func (c *apiClient) SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface {
 	return c.auth.SelfSubjectAccessReviews()
+}
+
+func (c *apiClient) SubjectAccessReviews() SubjectAccessReviewInterface {
+	return c.auth.SubjectAccessReviews()
 }
 
 type registryClient struct {

--- a/pkg/dockerregistry/server/client/interfaces.go
+++ b/pkg/dockerregistry/server/client/interfaces.go
@@ -69,6 +69,10 @@ type SelfSubjectAccessReviewsNamespacer interface {
 	SelfSubjectAccessReviews() SelfSubjectAccessReviewInterface
 }
 
+type SubjectAccessReviewsNamespacer interface {
+	SubjectAccessReviews() SubjectAccessReviewInterface
+}
+
 var _ ImageSignatureInterface = imageclientv1.ImageSignatureInterface(nil)
 
 type ImageSignatureInterface interface {
@@ -139,4 +143,10 @@ var _ SelfSubjectAccessReviewInterface = authclientv1.SelfSubjectAccessReviewInt
 
 type SelfSubjectAccessReviewInterface interface {
 	Create(ctx context.Context, selfSubjectAccessReview *authapiv1.SelfSubjectAccessReview, opts metav1.CreateOptions) (*authapiv1.SelfSubjectAccessReview, error)
+}
+
+var _ SubjectAccessReviewInterface = authclientv1.SubjectAccessReviewInterface(nil)
+
+type SubjectAccessReviewInterface interface {
+	Create(ctx context.Context, subjectAccessReview *authapiv1.SubjectAccessReview, opts metav1.CreateOptions) (*authapiv1.SubjectAccessReview, error)
 }


### PR DESCRIPTION
## What

Use `subjectaccessreviews` instead of `selfsubjectaccessreviews` for access denied and check for anonymous access.

## Why

SSAR doesn't work anymore with [AUTH-509](https://issues.redhat.com/browse/AUTH-509), but we can do a SAR instead and specifying the user / group as anonymous to avoid a regression in 4.16

## Note

- Depends on https://github.com/openshift/cluster-image-registry-operator/pull/1046
- WIP, need to clean it up