### PR TITLE
IR-489: export storage read-only errors as metrics

### DIFF
--- a/pkg/dockerregistry/server/metrics/errorcodes.go
+++ b/pkg/dockerregistry/server/metrics/errorcodes.go
@@ -1,13 +1,33 @@
 package metrics
 
-import storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+import (
+	"errors"
+	"io/fs"
+	"syscall"
+
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+)
 
 const (
 	errCodeUnsupportedMethod = "UNSUPPORTED_METHOD"
 	errCodePathNotFound      = "PATH_NOT_FOUND"
 	errCodeInvalidPath       = "INVALID_PATH"
 	errCodeInvalidOffset     = "INVALID_OFFSET"
+	errCodeReadOnlyFS        = "READ_ONLY_FILESYSTEM"
+	errCodeFileTooLarge      = "FILE_TOO_LARGE"
+	errCodeDeviceOutOfSpace  = "DEVICE_OUT_OF_SPACE"
 	errCodeUnknown           = "UNKNOWN"
+
+	// errnoEFBIG represents a file too large error.
+	// See `man errno` for more.
+	errnoEFBIG = 27
+	// errnoENOSPC represents a device out of space error.
+	// See `man errno` for more.
+	errnoENOSPC = 28
+	// errnoEROFS represents the syscall error number returned when an attempt
+	// to write to a read-only filesystem was made.
+	// See `man errno` for more.
+	errnoEROFS = 30
 )
 
 func storageErrorCode(err error) string {
@@ -20,7 +40,38 @@ func storageErrorCode(err error) string {
 		return errCodeInvalidPath
 	case storagedriver.InvalidOffsetError:
 		return errCodeInvalidOffset
+	case storagedriver.Error:
+		var perr *fs.PathError
+		if !errors.As(actual.Enclosed, &perr) {
+			return errCodeUnknown
+		}
+		unwrapped := perr.Unwrap()
+		if unwrapped == nil {
+			return errCodeUnknown
+		}
+		errno, ok := unwrapped.(syscall.Errno)
+		if !ok {
+			return errCodeUnknown
+		}
+		return syscallErrnoToErrorCode(errno)
+
 	}
 
+	return errCodeUnknown
+}
+
+// syscallErrnoToErrorCode transforms the errno in an unwrapped fs.PathErr into
+// a storage error code used to report metrics.
+//
+// if the given errno is not known to us, return errCodeUnknown.
+func syscallErrnoToErrorCode(errno syscall.Errno) string {
+	switch errno {
+	case errnoEROFS:
+		return errCodeReadOnlyFS
+	case errnoEFBIG:
+		return errCodeFileTooLarge
+	case errnoENOSPC:
+		return errCodeDeviceOutOfSpace
+	}
 	return errCodeUnknown
 }

--- a/pkg/dockerregistry/server/metrics/errorcodes.go
+++ b/pkg/dockerregistry/server/metrics/errorcodes.go
@@ -1,0 +1,26 @@
+package metrics
+
+import storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+
+const (
+	errCodeUnsupportedMethod = "UNSUPPORTED_METHOD"
+	errCodePathNotFound      = "PATH_NOT_FOUND"
+	errCodeInvalidPath       = "INVALID_PATH"
+	errCodeInvalidOffset     = "INVALID_OFFSET"
+	errCodeUnknown           = "UNKNOWN"
+)
+
+func storageErrorCode(err error) string {
+	switch actual := err.(type) {
+	case storagedriver.ErrUnsupportedMethod:
+		return errCodeUnsupportedMethod
+	case storagedriver.PathNotFoundError:
+		return errCodePathNotFound
+	case storagedriver.InvalidPathError:
+		return errCodeInvalidPath
+	case storagedriver.InvalidOffsetError:
+		return errCodeInvalidOffset
+	}
+
+	return errCodeUnknown
+}

--- a/pkg/dockerregistry/server/metrics/metrics.go
+++ b/pkg/dockerregistry/server/metrics/metrics.go
@@ -122,20 +122,6 @@ func storageSentinelError(err error) bool {
 	return false
 }
 
-func storageErrorCode(err error) string {
-	switch err.(type) {
-	case storagedriver.ErrUnsupportedMethod:
-		return "UNSUPPORTED_METHOD"
-	case storagedriver.PathNotFoundError:
-		return "PATH_NOT_FOUND"
-	case storagedriver.InvalidPathError:
-		return "INVALID_PATH"
-	case storagedriver.InvalidOffsetError:
-		return "INVALID_OFFSET"
-	}
-	return "UNKNOWN"
-}
-
 type metrics struct {
 	sink Sink
 }
@@ -196,8 +182,7 @@ func (m *metrics) DigestCacheScoped() Cache {
 	}
 }
 
-type noopMetrics struct {
-}
+type noopMetrics struct{}
 
 var _ Metrics = noopMetrics{}
 


### PR DESCRIPTION
before this change, "read-only file system" errors would show up in the metrics as "UNKNOWN".

this commit inspects the enclosed storage path error and reports a metric reporting the failed operation.

---

## Testing this change

The below steps have been tested against `4.18.0-0.test-2024-09-26-122820-ci-ln-0y1k6pk-latest` on AWS.

### Set storage to read-only
Easiest way I could find to achieve this is to configure the registry to use a pvc, then edit the image-registry deployment to mount the pvc with `readOnly: true`.

**Set project to openshift-image-registry**
```
oc project openshift-image-registry
```

**Create the PVC**
```
cat << EOF | kubectl apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: image-registry-test-claim
  namespace: openshift-image-registry
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 5Gi
  storageClassName: gp3-csi
  volumeMode: Filesystem
EOF
```

**Configure storage to pvc**
```
oc edit configs.imageregistry/cluster
```
Update the following fields (fields not listed below should not change):
```
.spec
  defaultRoute: true
  replicas: 1
  rolloutStrategy: Recreate
  storage:
    pvc:
      claim: image-registry-test-claim
```

**Check PVC status**
Wait until the PVC status changes to "Bound", which means the image registry pod has successfully mounted it.
```
oc get pvc image-registry-test-claim -w
```

**Set the registry to unmanaged, and update PVC mount to readOnly**
```
oc patch configs.imageregistry cluster --type=merge -p '{"spec":{"managementState":"Unmanaged"}}'
```
Edit the image registry deployment:
```
oc edit deployment image-registry 
```
Find the image-registry-test-claim volume in `.spec.template.spec.volumes` and change it to:
```
      - name: registry-storage
        persistentVolumeClaim:
          claimName: image-registry-test-claim
          readOnly: true
```
Wait for a new pod, then check that the volume is mounted read-only:
```
oc get pods <image-registry-pod-name> -ojsonpath='{.spec.volumes[?(@.name=="registry-storage")]}'
```
Sample output:
```
{"name":"registry-storage","persistentVolumeClaim":{"claimName":"image-registry-test-claim","readOnly":true}}
```

**Import an image**
```
oc import-image --reference-policy=local hello-world:latest --from=docker.io/library/hello-world:latest --confirm
```

**Pull the image**
```
REGISTRY=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
podman login --tls-verify=false $REGISTRY -u unused -p $(oc whoami -t)
podman pull --tls-verify=false ${REGISTRY}/openshift-image-registry/hello-world
```

**Verify the logs for a failure to mirror**
While the import and pull will work just fine, writing to local storage will fail.
This can be verified by grepping the image-registry logs:
```
oc logs deploy/image-registry|grep 'Background mirroring'
```

This should output a log entry similar to the following:
```
time="2024-09-18T13:16:49.077558148Z" level=error msg="Background mirroring failed: error committing to storage: filesystem: mkdir /registry/docker: read-only file system" go.version="go1.22.5 (Red Hat 1.22.5-1.el9) X:strictfipsruntime" http.request.host=default-route-openshift-image-registry.apps.ci-ln-m1stck2-76ef8.origin-ci-int-aws.dev.rhcloud.com http.request.id=06ee4c04-b721-4b7b-9977-e7e99ac3c847 http.request.method=GET http.request.remoteaddr=78.72.22.80 http.request.uri="/v2/openshift-image-registry/hello-world/blobs/sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a" http.request.useragent="containers/5.31.1 (github.com/containers/image)" openshift.auth.user="kube:admin" vars.digest="sha256:d2c94e258dcb3c5ac2798d32e1249e42ef01cba4841c2234249495f87264ac5a" vars.name=openshift-image-registry/hello-world
```

**Verify metric in web console**
Open the openshift web console, choose Observe -> Metrics on the left-side menu, then filter the metrics by:
```
imageregistry_storage_errors_total
```
That should return at least one metric with code `READ_ONLY_FILESYSTEM`, similar to the below:
![image](https://github.com/user-attachments/assets/e1188ab3-38fe-4a77-a18b-dad804946a3d)

