### PR TITLE
OCPBUGS-38874: add ap-southeast-5 region

### DIFF
--- a/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
+++ b/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
@@ -42,6 +42,13 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 )
 
+// additionalRegions is a slice with regions not listed among the default
+// regions supported by aws-sdk-go v1. the v1 of the sdk is in maintenance
+// therefore it does not receive new regions as aws infrastructure grows.
+var additionalRegions = []string{
+	"ap-southeast-5",
+}
+
 const driverName = "s3aws"
 
 // minChunkSize defines the minimum multipart upload chunk size
@@ -128,6 +135,10 @@ func init() {
 		for region := range p.Regions() {
 			validRegions[region] = struct{}{}
 		}
+	}
+
+	for _, region := range additionalRegions {
+		validRegions[region] = struct{}{}
 	}
 
 	for _, objectACL := range []string{


### PR DESCRIPTION
this pr adds the ap-southeast-5 region to the list of supported regions. this change is made directly into the vendor directory and is intended only for test purposes. if we get the ok that this works we will make the changes and bumps necessary to land this in the right place.