### PR TITLE
OCPBUGS-38874,OCPBUGS-25981: bump docker-distribution to add new regions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,4 +120,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20241023082416-9b9c54dbc086
+replace github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250120104846-a24972526437

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0 h1:Kn16YZDBGwetg+pMQ
 github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/docker-distribution/v3 v3.0.0-20241023082416-9b9c54dbc086 h1:kM30ruFjxZiMWDYPcqWn3wc2YmDufuhBcBGMrTuCEXc=
-github.com/openshift/docker-distribution/v3 v3.0.0-20241023082416-9b9c54dbc086/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250120104846-a24972526437 h1:dZYOAoYFvh/VIGMBjo0lcHHA3cPZSUz+tPJbSa+h55E=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250120104846-a24972526437/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1 h1:jLERUXwvYY9+9oCz66oQ/XTZzeyH8RmCpxiImYVYnmA=
 github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=

--- a/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
+++ b/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
@@ -42,6 +42,17 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 )
 
+// additionalRegions is a slice with regions not listed among the default
+// regions supported by aws-sdk-go v1. the v1 of the sdk is in maintenance
+// therefore it does not receive new regions as aws infrastructure grows.
+var additionalRegions = []string{
+	"ap-southeast-5", // Asia Pacific (Malaysia)
+	"ap-southeast-7", // Asia Pacific (Thailand)
+	"ca-west-1",      // Canada West (Calgary)
+	"il-central-1",   // Israel (Tel Aviv)
+	"mx-central-1",   // Mexico (Central)
+}
+
 const driverName = "s3aws"
 
 // minChunkSize defines the minimum multipart upload chunk size
@@ -128,6 +139,10 @@ func init() {
 		for region := range p.Regions() {
 			validRegions[region] = struct{}{}
 		}
+	}
+
+	for _, region := range additionalRegions {
+		validRegions[region] = struct{}{}
 	}
 
 	for _, objectACL := range []string{
@@ -557,9 +572,8 @@ func New(params DriverParameters) (*Driver, error) {
 	awsConfig.WithUseDualStack(params.UseDualStack)
 
 	if params.SkipVerify {
-		httpTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		httpTransport := http.DefaultTransport.(*http.Transport).Clone()
+		httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		awsConfig.WithHTTPClient(&http.Client{
 			Transport: httpTransport,
 		})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -166,7 +166,7 @@ github.com/davecgh/go-spew/spew
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/oss
 github.com/denverdino/aliyungo/util
-# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20241023082416-9b9c54dbc086
+# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20250120104846-a24972526437
 ## explicit; go 1.18
 github.com/distribution/distribution/v3
 github.com/distribution/distribution/v3/configuration
@@ -1081,4 +1081,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20241023082416-9b9c54dbc086
+# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250120104846-a24972526437


### PR DESCRIPTION
bumping docker-distribution dependency as the new version includes a few new regions.

this bump also includes the changes introduced by
https://github.com/openshift/docker-distribution/pull/44.