### PR TITLE
IR-526: remove AWS region check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 replace (
-	github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085919-6be8390f1cc6
+	github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250619120448-77e6a16fa66e
 
 	// CVE-2025-30204
 	github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0 h1:Kn16YZDBGwetg+pMQ
 github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/docker-distribution/v3 v3.0.0-20250131085919-6be8390f1cc6 h1:p9nJcERMt+SGp6BHXp/bGRbtT5JfrTYzhJcoG8t/7Rk=
-github.com/openshift/docker-distribution/v3 v3.0.0-20250131085919-6be8390f1cc6/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250619120448-77e6a16fa66e h1:cn/OYy1KoFM2f7F+JjaINzQAz7RczxMaYhuSZKGdZmE=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250619120448-77e6a16fa66e/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d h1:iQfTKBmMcwFTxxVWV7U/C6GqgIIWTKD8l5HXslvn53s=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1 h1:jLERUXwvYY9+9oCz66oQ/XTZzeyH8RmCpxiImYVYnmA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/davecgh/go-spew/spew
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/oss
 github.com/denverdino/aliyungo/util
-# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085919-6be8390f1cc6
+# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20250619120448-77e6a16fa66e
 ## explicit; go 1.18
 github.com/distribution/distribution/v3
 github.com/distribution/distribution/v3/configuration
@@ -1081,6 +1081,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085919-6be8390f1cc6
+# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250619120448-77e6a16fa66e
 # github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2
 # golang.org/x/oauth2 => github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d


### PR DESCRIPTION
Bump docker-distribution to the last commit on `release-4.18` branch. This essentially disables the manual region check we used to do.