### PR TITLE
[release-4.17] OCPBUGS-60090: bump docker distribution to fix purgeuploads panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 )
 
 replace (
-	github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085920-07b230952f5e
+	github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250806112144-7577cb885173
 
 	// CVE-2025-30204
 	github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0 h1:Kn16YZDBGwetg+pMQ
 github.com/openshift/api v0.0.0-20240613141850-76a71dac36a0/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87 h1:JtLhaGpSEconE+1IKmIgCOof/Len5ceG6H1pk43yv5U=
 github.com/openshift/client-go v0.0.0-20240528061634-b054aa794d87/go.mod h1:3IPD4U0qyovZS4EFady2kqY32m8lGcbs/Wx+yprg9z8=
-github.com/openshift/docker-distribution/v3 v3.0.0-20250131085920-07b230952f5e h1:iY1SY3aqlBvbnzHYqN0NDFeOrVJbLue4ptx77s77R/E=
-github.com/openshift/docker-distribution/v3 v3.0.0-20250131085920-07b230952f5e/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250806112144-7577cb885173 h1:R4tPneg69RQE8P+7mMqp2lmQh0+HJgf4GDZxy5qrl6U=
+github.com/openshift/docker-distribution/v3 v3.0.0-20250806112144-7577cb885173/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d h1:iQfTKBmMcwFTxxVWV7U/C6GqgIIWTKD8l5HXslvn53s=
 github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 github.com/openshift/library-go v0.0.0-20240607134135-aed018c215a1 h1:jLERUXwvYY9+9oCz66oQ/XTZzeyH8RmCpxiImYVYnmA=

--- a/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
+++ b/vendor/github.com/distribution/distribution/v3/registry/storage/driver/s3-aws/s3.go
@@ -1168,6 +1168,16 @@ func (d *driver) doWalk(parentCtx context.Context, objectCount *int64, path, pre
 				}
 			}
 
+			// in some cases the _uploads dir might be empty. when this happens, it would
+			// be appended twice to the walkInfos slice, once as [...]/_uploads and
+			// once more erroneously as [...]/_uploads/. the easiest way to avoid this is
+			// to skip appending filePath to walkInfos if it ends in "/". the loop through
+			// dirs will already have handled it in that case, so it's safe to continue this
+			// loop.
+			if strings.HasSuffix(filePath, "/") {
+				continue
+			}
+
 			walkInfos = append(walkInfos, storagedriver.FileInfoInternal{
 				FileInfoFields: storagedriver.FileInfoFields{
 					IsDir:   false,
@@ -1442,8 +1452,6 @@ func (w *writer) Size() int64 {
 	return w.size
 }
 
-// Close flushes any remaining data in the buffer and releases the buffer back
-// to the pool.
 func (w *writer) Close() error {
 	if w.closed {
 		return fmt.Errorf("already closed")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/davecgh/go-spew/spew
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/oss
 github.com/denverdino/aliyungo/util
-# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085920-07b230952f5e
+# github.com/distribution/distribution/v3 v3.0.0+incompatible => github.com/openshift/docker-distribution/v3 v3.0.0-20250806112144-7577cb885173
 ## explicit; go 1.18
 github.com/distribution/distribution/v3
 github.com/distribution/distribution/v3/configuration
@@ -1081,6 +1081,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250131085920-07b230952f5e
+# github.com/distribution/distribution/v3 => github.com/openshift/docker-distribution/v3 v3.0.0-20250806112144-7577cb885173
 # github.com/golang-jwt/jwt/v4 => github.com/golang-jwt/jwt/v4 v4.5.2
 # golang.org/x/oauth2 => github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d


### PR DESCRIPTION
Depends on https://github.com/openshift/docker-distribution/pull/61