### PR TITLE
CNF-23049: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -252,7 +251,7 @@ func NewServer(ctx context.Context, dockerConfig *configuration.Configuration, e
 			pool := x509.NewCertPool()
 
 			for _, ca := range dockerConfig.HTTP.TLS.ClientCAs {
-				caPem, err := ioutil.ReadFile(ca)
+				caPem, err := os.ReadFile(ca)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/dockerregistry/server/blobdescriptorservice_test.go
+++ b/pkg/dockerregistry/server/blobdescriptorservice_test.go
@@ -3,7 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -150,7 +150,7 @@ func TestBlobDescriptorServiceIsApplied(t *testing.T) {
 		}
 
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Errorf("[%s] failed to read body: %v", tc.name, err)
 			} else if len(content) > 0 {

--- a/pkg/dockerregistry/server/configuration/configuration.go
+++ b/pkg/dockerregistry/server/configuration/configuration.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -181,7 +180,7 @@ type versionInfo struct {
 // openshift specific configuration.
 // Environment variables may be used to override configuration parameters.
 func Parse(rd io.Reader) (*configuration.Configuration, *Configuration, error) {
-	in, err := ioutil.ReadAll(rd)
+	in, err := io.ReadAll(rd)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/dockerregistry/server/signaturedispatcher.go
+++ b/pkg/dockerregistry/server/signaturedispatcher.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -100,7 +100,7 @@ func (s *signatureHandler) Put(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sig := signature{}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		s.handleError(s.ctx, ErrorCodeSignatureInvalid.WithDetail(err.Error()), w)
 		return

--- a/pkg/dockerregistry/server/signaturedispatcher_test.go
+++ b/pkg/dockerregistry/server/signaturedispatcher_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -116,7 +116,7 @@ func TestSignatureGet(t *testing.T) {
 		t.Fatalf("unexpected response status: %v", resp.StatusCode)
 	}
 
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read body: %v", err)
 	}

--- a/pkg/dockerregistry/server/util_test.go
+++ b/pkg/dockerregistry/server/util_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -31,7 +30,7 @@ func Test_getImportContext(t *testing.T) {
 	icsp := operatorfake.NewSimpleClientset().OperatorV1alpha1().ImageContentSourcePolicies()
 	idms := cfgfake.NewSimpleClientset().ConfigV1().ImageDigestMirrorSets()
 	itms := cfgfake.NewSimpleClientset().ConfigV1().ImageTagMirrorSets()
-	tmpCredDir, err := ioutil.TempDir("", "credentials")
+	tmpCredDir, err := os.MkdirTemp("", "credentials")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}
@@ -129,7 +128,7 @@ func Test_getImportContext(t *testing.T) {
 			}
 
 			if len(tt.creds) > 0 {
-				if err := ioutil.WriteFile(
+				if err := os.WriteFile(
 					tmpCredDir+"/config.json", tt.creds, 0644,
 				); err != nil {
 					t.Errorf("error writing config.json: %v", err)

--- a/pkg/kubernetes-common/credentialprovider/config.go
+++ b/pkg/kubernetes-common/credentialprovider/config.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -99,7 +99,7 @@ func ReadDockercfgFile(searchPaths []string) (cfg DockerConfig, err error) {
 			continue
 		}
 		klog.V(4).Infof("looking for .dockercfg at %s", absDockerConfigFileLocation)
-		contents, err := ioutil.ReadFile(absDockerConfigFileLocation)
+		contents, err := os.ReadFile(absDockerConfigFileLocation)
 		if os.IsNotExist(err) {
 			continue
 		}
@@ -147,7 +147,7 @@ func ReadDockerConfigJSONFile(searchPaths []string) (cfg DockerConfig, err error
 func ReadSpecificDockerConfigJsonFile(filePath string) (cfg DockerConfig, err error) {
 	var contents []byte
 
-	if contents, err = ioutil.ReadFile(filePath); err != nil {
+	if contents, err = os.ReadFile(filePath); err != nil {
 		return nil, err
 	}
 	return readDockerConfigJsonFileFromBytes(contents)
@@ -195,7 +195,7 @@ func ReadUrl(url string, client *http.Client, header *http.Header) (body []byte,
 		}
 	}
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubernetes-common/credentialprovider/config_test.go
+++ b/pkg/kubernetes-common/credentialprovider/config_test.go
@@ -18,7 +18,6 @@ package credentialprovider
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -32,7 +31,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 	//test dockerconfig json
 	inputDockerconfigJsonFile := "{ \"auths\": { \"http://foo.example.com\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"foo@example.com\"}}}"
 
-	preferredPath, err := ioutil.TempDir("", "test_foo_bar_dockerconfigjson_")
+	preferredPath, err := os.MkdirTemp("", "test_foo_bar_dockerconfigjson_")
 	if err != nil {
 		t.Fatalf("Creating tmp dir fail: %v", err)
 		return

--- a/pkg/origin-common/clientcmd/clientcmd.go
+++ b/pkg/origin-common/clientcmd/clientcmd.go
@@ -2,7 +2,6 @@ package clientcmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -146,7 +145,7 @@ func (cfg *Config) bindEnv() error {
 		cfg.CommonConfig.BearerToken = value
 	}
 	if value, ok := getEnv("BEARER_TOKEN_FILE"); ok && len(cfg.CommonConfig.BearerToken) == 0 {
-		if tokenData, tokenErr := ioutil.ReadFile(value); tokenErr == nil {
+		if tokenData, tokenErr := os.ReadFile(value); tokenErr == nil {
 			cfg.CommonConfig.BearerToken = strings.TrimSpace(string(tokenData))
 			if len(cfg.CommonConfig.BearerToken) == 0 {
 				err = fmt.Errorf("BEARER_TOKEN_FILE %q was empty", value)

--- a/pkg/testframework/registry.go
+++ b/pkg/testframework/registry.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -535,7 +535,7 @@ func checkRoute(host string) error {
 	// if deployed registry leverages basic authentication a StatusUnauthorized will
 	// be returned so we consider this status as valid as well.
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusUnauthorized {
-		dt, err := ioutil.ReadAll(res.Body)
+		dt, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}

--- a/pkg/testutil/logrus.go
+++ b/pkg/testutil/logrus.go
@@ -2,7 +2,7 @@ package testutil
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -35,7 +35,7 @@ func (h *logrusHook) Fire(e *logrus.Entry) error {
 func WithTestLogger(parent context.Context, t *testing.T) context.Context {
 	log := logrus.New()
 	log.Level = logrus.DebugLevel
-	log.Out = ioutil.Discard
+	log.Out = io.Discard
 	log.Hooks.Add(&logrusHook{t: t})
 	return dcontext.WithLogger(parent, logrus.NewEntry(log))
 }

--- a/test/integration/imagelayers/imagelayers_test.go
+++ b/test/integration/imagelayers/imagelayers_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -35,7 +35,7 @@ func getSchema1Manifest(repo *testframework.Repository, tag string) (distributio
 		return nil, fmt.Errorf("get manifest %s:%s: %s", repo.RepoName(), tag, resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read manifest %s:%s: %v", repo.RepoName(), tag, err)
 	}

--- a/test/integration/pullthrough/pullthrough_test.go
+++ b/test/integration/pullthrough/pullthrough_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -45,7 +45,7 @@ func testPullThroughGetManifest(baseURL string, stream *imageapiv1.ImageStreamIm
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error reading manifest: %v", err)
 	}

--- a/test/integration/v2/v2_docker_registry_test.go
+++ b/test/integration/v2/v2_docker_registry_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -158,7 +158,7 @@ func TestV2RegistryGetTags(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("error retrieving manifest: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestV2RegistryGetTags(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", resp.StatusCode)
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("error retrieving manifest: %v", err)
 	}
@@ -347,7 +347,7 @@ func getTags(baseURL, namespace, streamName, user, token string) ([]string, erro
 	if resp.StatusCode != http.StatusOK {
 		return []string{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []string{}, fmt.Errorf("error retrieving manifest: %v", err)
 	}
@@ -387,7 +387,7 @@ func ping(baseURL, user, token string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error retrieving manifest: %v", err)
 	}

--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -303,7 +302,7 @@ func mergePackages(existingPackages, currPackages []Package) []Package {
 }
 
 func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
-	config, err := ioutil.ReadFile(configFile)
+	config, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration from %s: %v", configFile, err)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Core refactoring: Replace `ioutil` usage with `io` and `os` equivalents**

* Replaced all instances of `ioutil.ReadFile` with `os.ReadFile` for reading files, and `ioutil.WriteFile` with `os.WriteFile` for writing files in multiple files, such as `dockerregistry.go`, `config.go`, and their respective test files. [[1]](diffhunk://#diff-6035b3bd663e609f025b52f72242c3d48492376feddbfd2cd4cb8b58c1752142L255-R254) [[2]](diffhunk://#diff-f1ce15bbc295bdc35ea0f377b3b9564a42701da6f9fcc208a2824b62e99ad346L102-R102) [[3]](diffhunk://#diff-f1ce15bbc295bdc35ea0f377b3b9564a42701da6f9fcc208a2824b62e99ad346L150-R150) [[4]](diffhunk://#diff-5b3ce3a1b2724d13244ee5f889f1bb86dc128c209c4f9a44ed0bca4515d1fe3cL132-R131) [[5]](diffhunk://#diff-094b7f72c5fff9896d0cd8c947278e715dc5f33ebe2bd6d8649f9b5865427a8eL149-R148) [[6]](diffhunk://#diff-164de435a88631c7a106f4aa350659bc4bb04790f101b371019b84675701b3a8L306-R305)
* Replaced all instances of `ioutil.ReadAll` with `io.ReadAll` for reading from readers and response bodies, affecting HTTP handlers, test helpers, and utility functions. [[1]](diffhunk://#diff-9f57a78c15207400fdf744db30bf955c30f591e762e3912a29503389452a349bL184-R183) [[2]](diffhunk://#diff-a215f9ef5344e2e492dbb2e3b82acf1d51f330e76e2c1dcc51b10a896e2d22fcL103-R103) [[3]](diffhunk://#diff-0388713dc89d6d46ebdca20e35b6805e50b7bd2feee168e74c5c454e2bfebc13L119-R119) [[4]](diffhunk://#diff-ad7c954c84190c27f607a1f039d013df7e067258c6b1b3dee3802ece5557ac52L153-R153) [[5]](diffhunk://#diff-f1ce15bbc295bdc35ea0f377b3b9564a42701da6f9fcc208a2824b62e99ad346L198-R198) [[6]](diffhunk://#diff-bbb272591c8b7d8b590e4dd1320efb872d53784d695cdc2f0f580ab726a8cf7dL538-R539) [[7]](diffhunk://#diff-d238bbb1af5b8edaad349e855919c044eeb58e2a4c93db440dcb54acfd729b72L38-R38) [[8]](diffhunk://#diff-fecee6b59c9160da893e00659e586f7d4d0ed5a9811bd14af3e774968c054f09L48-R48) [[9]](diffhunk://#diff-7ee837186954fc33961678cbbe87c0407d48b6756c96de5170816fc44d113bf8L161-R161) [[10]](diffhunk://#diff-7ee837186954fc33961678cbbe87c0407d48b6756c96de5170816fc44d113bf8L191-R191) [[11]](diffhunk://#diff-7ee837186954fc33961678cbbe87c0407d48b6756c96de5170816fc44d113bf8L350-R350) [[12]](diffhunk://#diff-7ee837186954fc33961678cbbe87c0407d48b6756c96de5170816fc44d113bf8L390-R390)
* Replaced `ioutil.TempDir` with `os.MkdirTemp` for creating temporary directories in tests. [[1]](diffhunk://#diff-5b3ce3a1b2724d13244ee5f889f1bb86dc128c209c4f9a44ed0bca4515d1fe3cL34-R33) [[2]](diffhunk://#diff-203e4586110fea147a9c3617cabc4309cfff1ca46763826033892391e4e141c1L35-R34)
* Replaced `ioutil.Discard` with `io.Discard` for discarding output in logger setup.
* Removed deprecated `ioutil` import statements and updated import blocks accordingly across all affected files. [[1]](diffhunk://#diff-6035b3bd663e609f025b52f72242c3d48492376feddbfd2cd4cb8b58c1752142L10) [[2]](diffhunk://#diff-ad7c954c84190c27f607a1f039d013df7e067258c6b1b3dee3802ece5557ac52L6-R6) [[3]](diffhunk://#diff-9f57a78c15207400fdf744db30bf955c30f591e762e3912a29503389452a349bL8) [[4]](diffhunk://#diff-a215f9ef5344e2e492dbb2e3b82acf1d51f330e76e2c1dcc51b10a896e2d22fcL8-R8) [[5]](diffhunk://#diff-0388713dc89d6d46ebdca20e35b6805e50b7bd2feee168e74c5c454e2bfebc13L8-R8) [[6]](diffhunk://#diff-5b3ce3a1b2724d13244ee5f889f1bb86dc128c209c4f9a44ed0bca4515d1fe3cL5) [[7]](diffhunk://#diff-f1ce15bbc295bdc35ea0f377b3b9564a42701da6f9fcc208a2824b62e99ad346L23-R23) [[8]](diffhunk://#diff-203e4586110fea147a9c3617cabc4309cfff1ca46763826033892391e4e141c1L21) [[9]](diffhunk://#diff-094b7f72c5fff9896d0cd8c947278e715dc5f33ebe2bd6d8649f9b5865427a8eL5) [[10]](diffhunk://#diff-bbb272591c8b7d8b590e4dd1320efb872d53784d695cdc2f0f580ab726a8cf7dL9-R12) [[11]](diffhunk://#diff-947f7e5545974e471c0c6f175d3e65bf96e5d1c77f949d62108b380a67209ea2L5-R5) [[12]](diffhunk://#diff-d238bbb1af5b8edaad349e855919c044eeb58e2a4c93db440dcb54acfd729b72L5-R5) [[13]](diffhunk://#diff-fecee6b59c9160da893e00659e586f7d4d0ed5a9811bd14af3e774968c054f09L7-R7) [[14]](diffhunk://#diff-7ee837186954fc33961678cbbe87c0407d48b6756c96de5170816fc44d113bf8L7-R7) [[15]](diffhunk://#diff-164de435a88631c7a106f4aa350659bc4bb04790f101b371019b84675701b3a8L8)

These changes ensure the codebase is compatible with newer Go versions and follows up-to-date language standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized file, stream, and response-body handling across registry, credential, client, testing, and tooling components.
  * Replaced deprecated Go I/O helpers with supported standard library APIs.
  * Preserved existing functionality, configuration behavior, error handling, request processing, and public interfaces.
  * No user-facing behavior changes are expected from this maintenance update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->