### PR TITLE
TRT-2507: Revert #459 "IR-350: fix cipher suite configuration conflict with docker distribution"

### DIFF
--- a/pkg/cmd/dockerregistry/dockerregistry.go
+++ b/pkg/cmd/dockerregistry/dockerregistry.go
@@ -233,7 +233,7 @@ func NewServer(ctx context.Context, dockerConfig *configuration.Configuration, e
 				return nil, fmt.Errorf("invalid TLS version %q specified in REGISTRY_HTTP_TLS_MINVERSION: %v (valid values are %q)", s, err, crypto.ValidTLSVersions())
 			}
 		}
-		if s := os.Getenv("OPENSHIFT_REGISTRY_HTTP_TLS_CIPHERSUITES"); len(s) > 0 {
+		if s := os.Getenv("REGISTRY_HTTP_TLS_CIPHERSUITES"); len(s) > 0 {
 			for _, cipher := range strings.Split(s, ",") {
 				cipherSuite, err := crypto.CipherSuite(cipher)
 				if err != nil {


### PR DESCRIPTION

Reverts #459 ; tracked by [TRT-2507](https://issues.redhat.com//browse/TRT-2507)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR is suspect of failing serial testsuite on nightly payloads, starting with https://amd64.ocp.releases.ci.openshift.org/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2026-01-16-040717?from=4.22.0-0.nightly-2026-01-15-202111

Most recent failing payload: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2026-01-16-121608

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.22-e2e-aws-ovn-techpreview-serial-3of3/2012065131084648448
Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.22-e2e-azure-ovn-serial/2012015267789410304

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.22-e2e-aws-ovn-serial-2of2
```

CC: @ricardomaraschini

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
