### PR TITLE
OCPBUGS-99398: Fix resolveUpstreamRef to properly propagate not-found errors

### DIFF
--- a/pkg/imagestream/imagestream.go
+++ b/pkg/imagestream/imagestream.go
@@ -233,10 +233,9 @@ func (is *imageStream) GetImageOfImageStream(ctx context.Context, dgst digest.Di
 func (is *imageStream) resolveUpstreamRef(ctx context.Context, dgst digest.Digest) (reference.DockerImageReference, rerrors.Error) {
 	layers, rErr := is.imageStreamGetter.layers()
 	if rErr != nil {
-		return reference.DockerImageReference{}, rerrors.NewError(
-			ErrImageStreamUnknownErrorCode,
-			fmt.Sprintf("resolveUpstreamRef: failed to get layers for image stream %s", is.Reference()),
+		return reference.DockerImageReference{}, convertImageStreamGetterError(
 			rErr,
+			fmt.Sprintf("resolveUpstreamRef: failed to get layers for image stream %s", is.Reference()),
 		)
 	}
 

--- a/pkg/imagestream/imagestream.go
+++ b/pkg/imagestream/imagestream.go
@@ -199,6 +199,13 @@ func (is *imageStream) getImageOfImageStream(ctx context.Context, dgst digest.Di
 // not be sent to the master API. If you need unmodified version of the
 // image object, please use getStoredImageOfImageStream.
 func (is *imageStream) GetImageOfImageStream(ctx context.Context, dgst digest.Digest) (*imageapiv1.Image, rerrors.Error) {
+	if _, rErr := is.imageStreamGetter.get(); rErr != nil {
+		return nil, convertImageStreamGetterError(
+			rErr,
+			fmt.Sprintf("GetImageOfImageStream: image stream %s not found", is.Reference()),
+		)
+	}
+
 	isImage, err := is.getImageOfImageStream(ctx, dgst)
 	if err == nil {
 		return isImage, nil

--- a/pkg/imagestream/imagestream_error_test.go
+++ b/pkg/imagestream/imagestream_error_test.go
@@ -1,0 +1,46 @@
+package imagestream
+
+import (
+	"testing"
+
+	rerrors "github.com/openshift/image-registry/pkg/errors"
+)
+
+func TestConvertImageStreamGetterError(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputCode    string
+		expectedCode string
+	}{
+		{
+			name:         "NotFound error is propagated as ImageStream NotFound",
+			inputCode:    ErrImageStreamGetterNotFoundCode,
+			expectedCode: ErrImageStreamNotFoundCode,
+		},
+		{
+			name:         "Forbidden error is propagated as ImageStream Forbidden",
+			inputCode:    ErrImageStreamGetterForbiddenCode,
+			expectedCode: ErrImageStreamForbiddenCode,
+		},
+		{
+			name:         "Unknown error remains as ImageStream Unknown",
+			inputCode:    ErrImageStreamGetterUnknownCode,
+			expectedCode: ErrImageStreamUnknownErrorCode,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inputErr := rerrors.NewError(tc.inputCode, "test/repo", nil)
+			result := convertImageStreamGetterError(inputErr, "test message")
+
+			if result.Code() != tc.expectedCode {
+				t.Errorf("expected error code %q, got %q", tc.expectedCode, result.Code())
+			}
+
+			if result.Message() != "test message" {
+				t.Errorf("expected message %q, got %q", "test message", result.Message())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix resolveUpstreamRef() to use convertImageStreamGetterError() instead of hardcoding ErrImageStreamUnknownErrorCode, so that not-found errors from imageStreamGetter.layers() are properly converted to ErrImageStreamNotFoundCode.
- This fixes HTTP 500 responses on manifest HEAD requests for non-existent ImageStreams, which broke ImageStream auto-creation with Docker Engine 29+ clients.

## Problem

Docker Engine 29+ (with containerd image store) wraps single-platform images in OCI indexes and issues HEAD requests to check sub-manifest existence before PUT. When the ImageStream does not exist, manifestService.Exists() -> GetImageOfImageStream() -> resolveUpstreamRef() returns ErrImageStreamUnknownErrorCode instead of ErrImageStreamNotFoundCode, causing the registry to respond with HTTP 500 instead of 404.

This prevents the Docker client from proceeding to the manifest PUT, which is where CreateImageStreamMapping() auto-provisions the ImageStream.

## Root Cause

resolveUpstreamRef() was the only method in pkg/imagestream/imagestream.go that did not use convertImageStreamGetterError() to translate getter errors. All other methods (ResolveImageID, TagIsInsecure, Exists, localRegistry, IdentifyCandidateRepositories, Tags) already use this pattern.

## Test plan

- [ ] Verify the fix compiles and passes existing unit tests
- [ ] Push an image with Docker 29+ to a non-existent ImageStream and confirm auto-creation works
- [ ] Confirm existing pull-through and manifest operations are unaffected

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-99398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when image streams or image layers cannot be retrieved, providing more accurate error classification and preserving the original error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->